### PR TITLE
IDX-65: Fix the execution of the Cedar integration tests

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   build:
+    defaults:
+      run:
+        shell: bash
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -30,7 +30,7 @@ jobs:
         run: go test -count=1 -v -tags corpus ./integration_tests/... | tail
 
       - name: Notify on Failure
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,6 +40,6 @@ jobs:
               repo: context.repo.repo,
               title: 'Nightly Test Corpus Failed',
               body: 'The Nightly Test Corpus workflow failed. Please investigate.',
-              assignees: ['jmccarthy', 'philhassey'],
+              assignees: ['jmccarthy', 'philhassey', 'patjakdev'],
               labels: ['bug']
             })

--- a/integration_tests/corpus_test.go
+++ b/integration_tests/corpus_test.go
@@ -115,7 +115,7 @@ func TestCorpus(t *testing.T) {
 						Resource:  cedar.EntityUID(q.Resource),
 						Context:   q.Context,
 					})
-					if ok != (q.Decision == "Allow") {
+					if ok != (q.Decision == "allow") {
 						t.Fatalf("got %v want %v", ok, q.Decision)
 					}
 					var errors []string

--- a/integration_tests/corpus_test.go
+++ b/integration_tests/corpus_test.go
@@ -20,10 +20,10 @@ var integrationFS embed.FS
 type corpusTest struct {
 	Schema         string `json:"schema"`
 	Policies       string `json:"policies"`
-	ShouldValidate bool   `json:"should_validate"`
+	ShouldValidate bool   `json:"shouldValidate"`
 	Entities       string `json:"entities"`
 	Requests       []struct {
-		Desc      string       `json:"desc"`
+		Desc      string       `json:"description"`
 		Principal jsonEntity   `json:"principal"`
 		Action    jsonEntity   `json:"action"`
 		Resource  jsonEntity   `json:"resource"`
@@ -45,13 +45,7 @@ func TestCorpus(t *testing.T) {
 			t.Fatal("err loading tests", p, err)
 		}
 		for _, tn := range more {
-			if strings.Contains(tn, "schema_") {
-				continue
-			}
-			if strings.Contains(tn, ".cedarschema.json") {
-				continue
-			}
-			if strings.Contains(tn, ".entities.json") {
+			if strings.Contains(tn, "entities.json") {
 				continue
 			}
 			tests = append(tests, tn)

--- a/integration_tests/corpus_test.go
+++ b/integration_tests/corpus_test.go
@@ -74,8 +74,8 @@ func TestCorpus(t *testing.T) {
 		return "tmp/" + v
 	}
 
-	// detect possible corpus data pipeline failure
-	if len(tests) < 4_000 {
+	// detect possible corpus data pipeline failure. As of 2024/07/02, there were 1982 tests.
+	if len(tests) < 100 {
 		t.Fatalf("corpus test count too low: %v", len(tests))
 	}
 


### PR DESCRIPTION
There are myriad different issues addressed in this PR, but the result is that the corpus tests now run successfully and pass:

1. We now use `shell: bash` in the Github action. This sets the `-o pipefail` behavior that you might expect to be a default (see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference). Without this setting, `go test -count=1 -v -tags corpus ./integration_tests/... | tail` will always return a success error code.
2. As written, the Github action would create an issue any time the integration tests failed, even if they were run manually. We really only want to create issues if the automated nightly tests start failing.
3. The number of corpus tests has dropped below our threshold for assuming we've somehow screwed up the extraction of the tests from the published tarfile. I updated the threshold to 100, an order of magnitude below the current count of tests. The commit that reduced the test count appears to have been [this one](https://github.com/cedar-policy/cedar-integration-tests/commit/b6e804015b853925aadcf8dbb7c280e21cb372c2).
4. Fixes a casing error in the comparison with the decision string from the test.