### PR TITLE
This commit adds the extention types, datetime and duration to Cedar Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Go implementation includes:
 
 - the core authorizer
 - JSON marshalling and unmarshalling
-- all core and extended types
+- all core and extended types (including [RFC 80](https://github.com/cedar-policy/rfcs/blob/main/text/0080-datetime-extension.md)'s datetime and duration)
 - integration test suite
 
 The Go implementation does not yet include:
@@ -132,6 +132,11 @@ compatibility promise.
 While in development (0.x.y), each tagged release may contain breaking changes.
 
 ## Change log
+
+### New features in 0.3.2
+
+- An implementation of the `datetime` and `duration` extension types specified in [RFC 80](https://github.com/cedar-policy/rfcs/blob/main/text/0080-datetime-extension.md).
+  - Note: While these types have been accepted into the language, they have not yet been formally analyzed in the [specification](https://github.com/cedar-policy/cedar-spec/).
 
 ### New features in 0.3.1
 

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -558,6 +558,41 @@ func TestIsAuthorized(t *testing.T) {
 			DiagErr:   1,
 		},
 		{
+			Name: "permit-when-duration",
+			Policy: `permit(principal,action,resource) when {
+				duration("9h8m") < (duration("10h")) &&
+				duration("9h8m") <= (duration("10h")) &&
+				duration("9h8m") > (duration("7h")) &&
+				duration("9h8m") >= (duration("7h")) &&
+				duration("1ms").toMilliseconds() == 1 &&
+				duration("1s").toSeconds() == 1 &&
+				duration("1m").toMinutes() == 1 &&
+				duration("1h").toHours() == 1 &&
+				duration("1d").toDays() == 1 &&
+        datetime("1970-01-01").toTime() == duration("0ms") &&
+        datetime("1970-01-01").offset(duration("1ms")).toTime() == duration("1ms") &&
+        datetime("1970-01-01T00:00:00.001Z").durationSince(datetime("1970-01-01")) == duration("1ms")};`,
+
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      true,
+			DiagErr:   0,
+		},
+		{
+			Name:      "permit-when-duration-fun-wrong-arity",
+			Policy:    `permit(principal,action,resource) when { duration("1h", "huh?") };`,
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      false,
+			DiagErr:   1,
+		},
+		{
 			Name: "permit-when-ip",
 			Policy: `permit(principal,action,resource) when {
 				ip("1.2.3.4").isIpv4() &&

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -531,6 +531,33 @@ func TestIsAuthorized(t *testing.T) {
 			DiagErr:   1,
 		},
 		{
+			Name: "permit-when-datetime",
+			Policy: `permit(principal,action,resource) when {
+				datetime("1970-01-01T09:08:07Z") < (datetime("1970-02-01")) &&
+				datetime("1970-01-01T09:08:07Z") <= (datetime("1970-02-01")) &&
+				datetime("1970-01-01T09:08:07Z") > (datetime("1970-01-01")) &&
+				datetime("1970-01-01T09:08:07Z") >= (datetime("1970-01-01")) &&
+        datetime("1970-01-01T09:08:07Z").toDate() == datetime("1970-01-01")};`,
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      true,
+			DiagErr:   0,
+		},
+		{
+			Name:      "permit-when-datetime-fun-wrong-arity",
+			Policy:    `permit(principal,action,resource) when { datetime("1970-01-01", "UTC") };`,
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      false,
+			DiagErr:   1,
+		},
+		{
 			Name: "permit-when-ip",
 			Policy: `permit(principal,action,resource) when {
 				ip("1.2.3.4").isIpv4() &&

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -7,6 +7,13 @@ const (
 	Context   = "context"
 )
 
+const (
+	MillisPerSecond = int64(1000)
+	MillisPerMinute = MillisPerSecond * 60
+	MillisPerHour   = MillisPerMinute * 60
+	MillisPerDay    = MillisPerHour * 24
+)
+
 func init() {
 	_ = 42
 }

--- a/internal/eval/comparable.go
+++ b/internal/eval/comparable.go
@@ -1,0 +1,17 @@
+package eval
+
+import "github.com/cedar-policy/cedar-go/types"
+
+// ComparableValue provides the interface that must be implemented to
+// support operator overloading of <, <=, >, and >=
+type ComparableValue interface {
+	types.Value
+
+	// LessThan returns true if the lhs is less than the rhs, and an
+	// error if the rhs is not comparable to the lhs
+	LessThan(types.Value) (bool, error)
+
+	// LessThan returns true if the lhs is less than or equal to the
+	// rhs, and an error if the rhs is not comparable to the lhs
+	LessThanOrEqual(types.Value) (bool, error)
+}

--- a/internal/eval/convert.go
+++ b/internal/eval/convert.go
@@ -64,13 +64,13 @@ func toEval(n ast.IsNode) Evaler {
 	case ast.NodeTypeNotEquals:
 		return newNotEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeGreaterThan:
-		return newVirtualGreaterThanEval(toEval(v.Left), toEval(v.Right))
+		return newComparableValueGreaterThanEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeGreaterThanOrEqual:
-		return newVirtualGreaterThanOrEqualEval(toEval(v.Left), toEval(v.Right))
+		return newComparableValueGreaterThanOrEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeLessThan:
-		return newVirtualLessThanEval(toEval(v.Left), toEval(v.Right))
+		return newComparableValueLessThanEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeLessThanOrEqual:
-		return newVirtualLessThanOrEqualEval(toEval(v.Left), toEval(v.Right))
+		return newComparableValueLessThanOrEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeSub:
 		return newSubtractEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeAdd:

--- a/internal/eval/convert.go
+++ b/internal/eval/convert.go
@@ -64,13 +64,13 @@ func toEval(n ast.IsNode) Evaler {
 	case ast.NodeTypeNotEquals:
 		return newNotEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeGreaterThan:
-		return newLongGreaterThanEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualGreaterThanEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeGreaterThanOrEqual:
-		return newLongGreaterThanOrEqualEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualGreaterThanOrEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeLessThan:
-		return newLongLessThanEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualLessThanEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeLessThanOrEqual:
-		return newLongLessThanOrEqualEval(toEval(v.Left), toEval(v.Right))
+		return newVirtualLessThanOrEqualEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeSub:
 		return newSubtractEval(toEval(v.Left), toEval(v.Right))
 	case ast.NodeTypeAdd:

--- a/internal/eval/convert_test.go
+++ b/internal/eval/convert_test.go
@@ -216,11 +216,66 @@ func TestToEval(t *testing.T) {
 			testutil.OK,
 		},
 		{
+			"duration",
+			ast.ExtensionCall("duration", ast.String("1ms")),
+			types.UnsafeDuration(1),
+			testutil.OK,
+		},
+		{
 			"toDate",
 			ast.ExtensionCall("toDate", ast.Value(types.UnsafeDatetime(1))),
 			types.UnsafeDatetime(0),
 			testutil.OK,
 		},
+		{
+			"toTime",
+			ast.ExtensionCall("toTime", ast.Value(types.UnsafeDatetime(1))),
+			types.UnsafeDuration(1),
+			testutil.OK,
+		},
+		{
+			"toDays",
+			ast.ExtensionCall("toDays", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toHours",
+			ast.ExtensionCall("toHours", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toMinutes",
+			ast.ExtensionCall("toMinutes", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toSeconds",
+			ast.ExtensionCall("toSeconds", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toMilliseconds",
+			ast.ExtensionCall("toMilliseconds", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"offset",
+			ast.ExtensionCall("offset", ast.Value(types.UnsafeDatetime(0)), ast.Value(types.UnsafeDuration(1))),
+			types.UnsafeDatetime(1),
+			testutil.OK,
+		},
+		{
+			"durationSince",
+			ast.ExtensionCall("durationSince", ast.Value(types.UnsafeDatetime(1)), ast.Value(types.UnsafeDatetime(1))),
+			types.UnsafeDuration(0),
+			testutil.OK,
+		},
+
 		{
 			"lessThan",
 			ast.ExtensionCall("lessThan", ast.Value(types.UnsafeDecimal(42.0)), ast.Value(types.UnsafeDecimal(43))),

--- a/internal/eval/convert_test.go
+++ b/internal/eval/convert_test.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/internal/ast"
 	"github.com/cedar-policy/cedar-go/internal/testutil"
@@ -212,67 +213,67 @@ func TestToEval(t *testing.T) {
 		{
 			"datetime",
 			ast.ExtensionCall("datetime", ast.String("1970-01-01T00:00:00.001Z")),
-			types.UnsafeDatetime(1),
+			types.FromStdTime(time.UnixMilli(1)),
 			testutil.OK,
 		},
 		{
 			"duration",
 			ast.ExtensionCall("duration", ast.String("1ms")),
-			types.UnsafeDuration(1),
+			types.FromStdDuration(1 * time.Millisecond),
 			testutil.OK,
 		},
 		{
 			"toDate",
-			ast.ExtensionCall("toDate", ast.Value(types.UnsafeDatetime(1))),
-			types.UnsafeDatetime(0),
+			ast.ExtensionCall("toDate", ast.Value(types.FromStdTime(time.UnixMilli(1)))),
+			types.FromStdTime(time.UnixMilli(0)),
 			testutil.OK,
 		},
 		{
 			"toTime",
-			ast.ExtensionCall("toTime", ast.Value(types.UnsafeDatetime(1))),
-			types.UnsafeDuration(1),
+			ast.ExtensionCall("toTime", ast.Value(types.FromStdTime(time.UnixMilli(1)))),
+			types.FromStdDuration(1 * time.Millisecond),
 			testutil.OK,
 		},
 		{
 			"toDays",
-			ast.ExtensionCall("toDays", ast.Value(types.UnsafeDuration(0))),
+			ast.ExtensionCall("toDays", ast.Value(types.FromStdDuration(time.Duration(0)))),
 			types.Long(0),
 			testutil.OK,
 		},
 		{
 			"toHours",
-			ast.ExtensionCall("toHours", ast.Value(types.UnsafeDuration(0))),
+			ast.ExtensionCall("toHours", ast.Value(types.FromStdDuration(time.Duration(0)))),
 			types.Long(0),
 			testutil.OK,
 		},
 		{
 			"toMinutes",
-			ast.ExtensionCall("toMinutes", ast.Value(types.UnsafeDuration(0))),
+			ast.ExtensionCall("toMinutes", ast.Value(types.FromStdDuration(time.Duration(0)))),
 			types.Long(0),
 			testutil.OK,
 		},
 		{
 			"toSeconds",
-			ast.ExtensionCall("toSeconds", ast.Value(types.UnsafeDuration(0))),
+			ast.ExtensionCall("toSeconds", ast.Value(types.FromStdDuration(time.Duration(0)))),
 			types.Long(0),
 			testutil.OK,
 		},
 		{
 			"toMilliseconds",
-			ast.ExtensionCall("toMilliseconds", ast.Value(types.UnsafeDuration(0))),
+			ast.ExtensionCall("toMilliseconds", ast.Value(types.FromStdDuration(time.Duration(0)))),
 			types.Long(0),
 			testutil.OK,
 		},
 		{
 			"offset",
-			ast.ExtensionCall("offset", ast.Value(types.UnsafeDatetime(0)), ast.Value(types.UnsafeDuration(1))),
-			types.UnsafeDatetime(1),
+			ast.ExtensionCall("offset", ast.Value(types.FromStdTime(time.UnixMilli(0))), ast.Value(types.FromStdDuration(1*time.Millisecond))),
+			types.FromStdTime(time.UnixMilli(1)),
 			testutil.OK,
 		},
 		{
 			"durationSince",
-			ast.ExtensionCall("durationSince", ast.Value(types.UnsafeDatetime(1)), ast.Value(types.UnsafeDatetime(1))),
-			types.UnsafeDuration(0),
+			ast.ExtensionCall("durationSince", ast.Value(types.FromStdTime(time.UnixMilli(1))), ast.Value(types.FromStdTime(time.UnixMilli(1)))),
+			types.FromStdDuration(time.Duration(0)),
 			testutil.OK,
 		},
 

--- a/internal/eval/convert_test.go
+++ b/internal/eval/convert_test.go
@@ -210,6 +210,18 @@ func TestToEval(t *testing.T) {
 			testutil.OK,
 		},
 		{
+			"datetime",
+			ast.ExtensionCall("datetime", ast.String("1970-01-01T00:00:00.001Z")),
+			types.UnsafeDatetime(1),
+			testutil.OK,
+		},
+		{
+			"toDate",
+			ast.ExtensionCall("toDate", ast.Value(types.UnsafeDatetime(1))),
+			types.UnsafeDatetime(0),
+			testutil.OK,
+		},
+		{
 			"lessThan",
 			ast.ExtensionCall("lessThan", ast.Value(types.UnsafeDecimal(42.0)), ast.Value(types.UnsafeDecimal(43))),
 			types.True,

--- a/internal/eval/evalers_test.go
+++ b/internal/eval/evalers_test.go
@@ -970,12 +970,15 @@ func TestVirtualComparisonNodes(t *testing.T) {
 	t.Parallel()
 
 	var (
-		zero       = types.Long(0)
-		neg1       = types.Long(-1)
-		pos1       = types.Long(1)
-		zeroDate   = types.UnsafeDatetime(0)
-		futureDate = types.UnsafeDatetime(1)
-		pastDate   = types.UnsafeDatetime(-1)
+		zero         = types.Long(0)
+		neg1         = types.Long(-1)
+		pos1         = types.Long(1)
+		zeroDate     = types.UnsafeDatetime(0)
+		futureDate   = types.UnsafeDatetime(1)
+		pastDate     = types.UnsafeDatetime(-1)
+		zeroDuration = types.UnsafeDuration(0)
+		negDuration  = types.UnsafeDuration(-1)
+		posDuration  = types.UnsafeDuration(1)
 	)
 
 	type test struct {
@@ -1014,6 +1017,17 @@ func TestVirtualComparisonNodes(t *testing.T) {
 				{futureDate, zeroDate, false, nil},
 				{futureDate, futureDate, false, nil},
 
+				// Duration
+				{negDuration, negDuration, false, nil},
+				{negDuration, zeroDuration, true, nil},
+				{negDuration, posDuration, true, nil},
+				{zeroDuration, negDuration, false, nil},
+				{zeroDuration, zeroDuration, false, nil},
+				{zeroDuration, posDuration, true, nil},
+				{posDuration, negDuration, false, nil},
+				{posDuration, zeroDuration, false, nil},
+				{posDuration, posDuration, false, nil},
+
 				// Errors
 				{errTest, neg1, false, errTest},
 				{neg1, errTest, false, errTest},
@@ -1044,6 +1058,17 @@ func TestVirtualComparisonNodes(t *testing.T) {
 				{futureDate, pastDate, false, nil},
 				{futureDate, zeroDate, false, nil},
 				{futureDate, futureDate, true, nil},
+
+				// Duration
+				{negDuration, negDuration, true, nil},
+				{negDuration, zeroDuration, true, nil},
+				{negDuration, posDuration, true, nil},
+				{zeroDuration, negDuration, false, nil},
+				{zeroDuration, zeroDuration, true, nil},
+				{zeroDuration, posDuration, true, nil},
+				{posDuration, negDuration, false, nil},
+				{posDuration, zeroDuration, false, nil},
+				{posDuration, posDuration, true, nil},
 
 				// Errors
 				{errTest, neg1, false, errTest},
@@ -1076,6 +1101,17 @@ func TestVirtualComparisonNodes(t *testing.T) {
 				{futureDate, zeroDate, true, nil},
 				{futureDate, futureDate, false, nil},
 
+				// Duration
+				{negDuration, negDuration, false, nil},
+				{negDuration, zeroDuration, false, nil},
+				{negDuration, posDuration, false, nil},
+				{zeroDuration, negDuration, true, nil},
+				{zeroDuration, zeroDuration, false, nil},
+				{zeroDuration, posDuration, false, nil},
+				{posDuration, negDuration, true, nil},
+				{posDuration, zeroDuration, true, nil},
+				{posDuration, posDuration, false, nil},
+
 				// Errors
 				{errTest, neg1, false, errTest},
 				{neg1, errTest, false, errTest},
@@ -1107,6 +1143,17 @@ func TestVirtualComparisonNodes(t *testing.T) {
 				{futureDate, zeroDate, true, nil},
 				{futureDate, futureDate, true, nil},
 
+				// Duration
+				{negDuration, negDuration, true, nil},
+				{negDuration, zeroDuration, false, nil},
+				{negDuration, posDuration, false, nil},
+				{zeroDuration, negDuration, true, nil},
+				{zeroDuration, zeroDuration, true, nil},
+				{zeroDuration, posDuration, false, nil},
+				{posDuration, negDuration, true, nil},
+				{posDuration, zeroDuration, true, nil},
+				{posDuration, posDuration, true, nil},
+
 				// Errors
 				{errTest, neg1, false, errTest},
 				{neg1, errTest, false, errTest},
@@ -1122,7 +1169,7 @@ func TestVirtualComparisonNodes(t *testing.T) {
 			t.Run(fmt.Sprintf("%v_%s_%v", tt.lhs, tc.name, tt.rhs), func(t *testing.T) {
 				t.Parallel()
 				n := tc.evaler(toEvaler(tt.lhs), toEvaler(tt.rhs))
-				v, err := n.Eval(&Context{})
+				v, err := n.Eval(&Env{})
 				if tt.wantErr == nil {
 					testutil.OK(t, err)
 					AssertBoolValue(t, v, tt.result)
@@ -2225,6 +2272,7 @@ func TestCedarString(t *testing.T) {
 		{"singleIP", types.IPAddr(netip.MustParsePrefix("192.168.0.42/32")), `192.168.0.42`, `ip("192.168.0.42")`},
 		{"ipPrefix", types.IPAddr(netip.MustParsePrefix("192.168.0.42/24")), `192.168.0.42/24`, `ip("192.168.0.42/24")`},
 		{"decimal", types.UnsafeDecimal(1234.5678), `1234.5678`, `decimal("1234.5678")`},
+		{"duration", types.UnsafeDuration(1), `1ms`, `duration("1ms")`},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -2261,5 +2309,247 @@ func TestCache(t *testing.T) {
 	res, err = newInEval(e1Eval, e2Eval).Eval(env)
 	testutil.OK(t, err)
 	testutil.Equals(t, res, types.Value(types.False))
+}
 
+func TestDatetimeToDate(t *testing.T) {
+	t.Parallel()
+	aTime, err := types.ParseDatetime("1970-01-02T10:00:00Z")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(aTime), types.UnsafeDatetime(24 * 60 * 60 * 1000), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newToDateEval(tt.arg)
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDatetimeDurationSince(t *testing.T) {
+	t.Parallel()
+	aTime, err := types.ParseDatetime("1970-01-02T00:00:00Z")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(aTime), types.UnsafeDuration(24 * 60 * 60 * 1000), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newDurationSinceEval(tt.arg, newLiteralEval(types.UnsafeDatetime(0)))
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDatetimeOffset(t *testing.T) {
+	t.Parallel()
+	aTime, err := types.ParseDatetime("1970-01-01T00:00:00Z")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(aTime), types.UnsafeDatetime(24 * 60 * 60 * 1000), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newOffsetEval(tt.arg, newLiteralEval(types.UnsafeDuration(24*60*60*1000)))
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDatetimeToTime(t *testing.T) {
+	t.Parallel()
+	aTime, err := types.ParseDatetime("1970-01-01T10:00:00Z")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(aTime), types.UnsafeDuration(10 * 60 * 60 * 1000), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newToTimeEval(tt.arg)
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDurationToMilliseconds(t *testing.T) {
+	t.Parallel()
+	oneDay, err := types.ParseDuration("1d")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(oneDay), types.Long(24 * 60 * 60 * 1000), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newToMillisecondsEval(tt.arg)
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDurationToSeconds(t *testing.T) {
+	t.Parallel()
+	oneDay, err := types.ParseDuration("1d")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(oneDay), types.Long(24 * 60 * 60), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newToSecondsEval(tt.arg)
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDurationToMinutes(t *testing.T) {
+	t.Parallel()
+	oneDay, err := types.ParseDuration("1d")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(oneDay), types.Long(24 * 60), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newToMinutesEval(tt.arg)
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDurationToHours(t *testing.T) {
+	t.Parallel()
+	oneDay, err := types.ParseDuration("1d")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(oneDay), types.Long(24), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newToHoursEval(tt.arg)
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
+}
+
+func TestDurationToDays(t *testing.T) {
+	t.Parallel()
+	oneDay, err := types.ParseDuration("1d")
+	testutil.OK(t, err)
+
+	tests := []struct {
+		name   string
+		arg    Evaler
+		result types.Value
+		err    error
+	}{
+		{"Error", newErrorEval(errTest), zeroValue(), errTest},
+		{"TypeError", newLiteralEval(types.Long(1)), zeroValue(), ErrType},
+		{"Success", newLiteralEval(oneDay), types.Long(1), nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			n := newToDaysEval(tt.arg)
+			v, err := n.Eval(&Env{})
+			testutil.ErrorIs(t, err, tt.err)
+			AssertValue(t, v, tt.result)
+		})
+	}
 }

--- a/internal/eval/evalers_test.go
+++ b/internal/eval/evalers_test.go
@@ -947,6 +947,193 @@ func TestDecimalGreaterThanOrEqualNode(t *testing.T) {
 	}
 }
 
+// hack: newVirtualLessThanEval and friends aren't func(Evaler, Evaler) Evaler, but we can turn them into it with generics.
+func makeEvaler[T Evaler](fn func(Evaler, Evaler) T) func(Evaler, Evaler) Evaler {
+	return func(lhs Evaler, rhs Evaler) Evaler {
+		return fn(lhs, rhs)
+	}
+}
+
+// toEvaler lifts a Value or error into an Evaler
+func toEvaler(x any) Evaler {
+	switch v := x.(type) {
+	case types.Value:
+		return newLiteralEval(v)
+	case error:
+		return newErrorEval(v)
+	default:
+		panic(fmt.Sprintf("can't convert %T into Evaler", v))
+	}
+}
+
+func TestVirtualComparisonNodes(t *testing.T) {
+	t.Parallel()
+
+	var (
+		zero       = types.Long(0)
+		neg1       = types.Long(-1)
+		pos1       = types.Long(1)
+		zeroDate   = types.UnsafeDatetime(0)
+		futureDate = types.UnsafeDatetime(1)
+		pastDate   = types.UnsafeDatetime(-1)
+	)
+
+	type test struct {
+		lhs, rhs any
+		result   bool
+		wantErr  error
+	}
+	type testNode struct {
+		name   string
+		evaler func(Evaler, Evaler) Evaler
+		table  []test
+	}
+
+	tests := []testNode{
+		{name: "<",
+			evaler: makeEvaler(newVirtualLessThanEval),
+			table: []test{
+				{neg1, neg1, false, nil},
+				{neg1, zero, true, nil},
+				{neg1, pos1, true, nil},
+				{zero, neg1, false, nil},
+				{zero, zero, false, nil},
+				{zero, pos1, true, nil},
+				{pos1, neg1, false, nil},
+				{pos1, zero, false, nil},
+				{pos1, pos1, false, nil},
+
+				// Datetime
+				{pastDate, pastDate, false, nil},
+				{pastDate, zeroDate, true, nil},
+				{pastDate, futureDate, true, nil},
+				{zeroDate, pastDate, false, nil},
+				{zeroDate, zeroDate, false, nil},
+				{zeroDate, futureDate, true, nil},
+				{futureDate, pastDate, false, nil},
+				{futureDate, zeroDate, false, nil},
+				{futureDate, futureDate, false, nil},
+
+				// Errors
+				{errTest, neg1, false, errTest},
+				{neg1, errTest, false, errTest},
+				{types.True, neg1, false, ErrType},
+				{neg1, types.False, false, ErrType},
+			},
+		},
+		{name: "<=",
+			evaler: makeEvaler(newVirtualLessThanOrEqualEval),
+			table: []test{
+				{neg1, neg1, true, nil},
+				{neg1, zero, true, nil},
+				{neg1, pos1, true, nil},
+				{zero, neg1, false, nil},
+				{zero, zero, true, nil},
+				{zero, pos1, true, nil},
+				{pos1, neg1, false, nil},
+				{pos1, zero, false, nil},
+				{pos1, pos1, true, nil},
+
+				// Datetime
+				{pastDate, pastDate, true, nil},
+				{pastDate, zeroDate, true, nil},
+				{pastDate, futureDate, true, nil},
+				{zeroDate, pastDate, false, nil},
+				{zeroDate, zeroDate, true, nil},
+				{zeroDate, futureDate, true, nil},
+				{futureDate, pastDate, false, nil},
+				{futureDate, zeroDate, false, nil},
+				{futureDate, futureDate, true, nil},
+
+				// Errors
+				{errTest, neg1, false, errTest},
+				{neg1, errTest, false, errTest},
+				{types.True, neg1, false, ErrType},
+				{neg1, types.False, false, ErrType},
+			},
+		},
+		{name: ">",
+			evaler: makeEvaler(newVirtualGreaterThanEval),
+			table: []test{
+				{neg1, neg1, false, nil},
+				{neg1, zero, false, nil},
+				{neg1, pos1, false, nil},
+				{zero, neg1, true, nil},
+				{zero, zero, false, nil},
+				{zero, pos1, false, nil},
+				{pos1, neg1, true, nil},
+				{pos1, zero, true, nil},
+				{pos1, pos1, false, nil},
+
+				// Datetime
+				{pastDate, pastDate, false, nil},
+				{pastDate, zeroDate, false, nil},
+				{pastDate, futureDate, false, nil},
+				{zeroDate, pastDate, true, nil},
+				{zeroDate, zeroDate, false, nil},
+				{zeroDate, futureDate, false, nil},
+				{futureDate, pastDate, true, nil},
+				{futureDate, zeroDate, true, nil},
+				{futureDate, futureDate, false, nil},
+
+				// Errors
+				{errTest, neg1, false, errTest},
+				{neg1, errTest, false, errTest},
+				{types.True, neg1, false, ErrType},
+				{neg1, types.False, false, ErrType},
+			},
+		},
+		{name: ">=",
+			evaler: makeEvaler(newVirtualGreaterThanOrEqualEval),
+			table: []test{
+				{neg1, neg1, true, nil},
+				{neg1, zero, false, nil},
+				{neg1, pos1, false, nil},
+				{zero, neg1, true, nil},
+				{zero, zero, true, nil},
+				{zero, pos1, false, nil},
+				{pos1, neg1, true, nil},
+				{pos1, zero, true, nil},
+				{pos1, pos1, true, nil},
+
+				// Datetime
+				{pastDate, pastDate, true, nil},
+				{pastDate, zeroDate, false, nil},
+				{pastDate, futureDate, false, nil},
+				{zeroDate, pastDate, true, nil},
+				{zeroDate, zeroDate, true, nil},
+				{zeroDate, futureDate, false, nil},
+				{futureDate, pastDate, true, nil},
+				{futureDate, zeroDate, true, nil},
+				{futureDate, futureDate, true, nil},
+
+				// Errors
+				{errTest, neg1, false, errTest},
+				{neg1, errTest, false, errTest},
+				{types.True, neg1, false, ErrType},
+				{neg1, types.False, false, ErrType},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		for _, tt := range tc.table {
+			t.Run(fmt.Sprintf("%v_%s_%v", tt.lhs, tc.name, tt.rhs), func(t *testing.T) {
+				t.Parallel()
+				n := tc.evaler(toEvaler(tt.lhs), toEvaler(tt.rhs))
+				v, err := n.Eval(&Context{})
+				if tt.wantErr == nil {
+					testutil.OK(t, err)
+					AssertBoolValue(t, v, tt.result)
+				} else {
+					testutil.ErrorIs(t, err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
 func TestIfThenElseNode(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/eval/util.go
+++ b/internal/eval/util.go
@@ -97,6 +97,14 @@ func ValueToDecimal(v types.Value) (types.Decimal, error) {
 	return d, nil
 }
 
+func ValueToDuration(v types.Value) (types.Duration, error) {
+	d, ok := v.(types.Duration)
+	if !ok {
+		return types.Duration{}, fmt.Errorf("%w: expected duration, got %v", ErrType, TypeName(v))
+	}
+	return d, nil
+}
+
 func ValueToIP(v types.Value) (types.IPAddr, error) {
 	i, ok := v.(types.IPAddr)
 	if !ok {

--- a/internal/eval/util.go
+++ b/internal/eval/util.go
@@ -12,6 +12,8 @@ func TypeName(v types.Value) string {
 		return "bool"
 	case types.Decimal:
 		return "decimal"
+	case types.Datetime:
+		return "datetime"
 	case types.EntityUID:
 		return fmt.Sprintf("(entity of type `%s`)", t.Type)
 	case types.IPAddr:
@@ -77,6 +79,14 @@ func ValueToEntity(v types.Value) (types.EntityUID, error) {
 		return types.EntityUID{}, fmt.Errorf("%w: expected (entity of type `any_entity_type`), got %v", ErrType, TypeName(v))
 	}
 	return ev, nil
+}
+
+func ValueToDatetime(v types.Value) (types.Datetime, error) {
+	d, ok := v.(types.Datetime)
+	if !ok {
+		return types.Datetime{}, fmt.Errorf("%w: expected datetime, got %v", ErrType, TypeName(v))
+	}
+	return d, nil
 }
 
 func ValueToDecimal(v types.Value) (types.Decimal, error) {

--- a/internal/eval/util_test.go
+++ b/internal/eval/util_test.go
@@ -119,6 +119,26 @@ func TestUtil(t *testing.T) {
 
 	})
 
+	t.Run("Datetime", func(t *testing.T) {
+		t.Parallel()
+		t.Run("roundTrip", func(t *testing.T) {
+			t.Parallel()
+			dv, err := types.ParseDatetime("2024-07-15T09:00:00Z")
+			testutil.OK(t, err)
+			v, err := ValueToDatetime(dv)
+			testutil.OK(t, err)
+			testutil.FatalIf(t, !v.Equal(dv), "got %v want %v", v, dv)
+		})
+
+		t.Run("toDatetimeOnNonDatetime", func(t *testing.T) {
+			t.Parallel()
+			v, err := ValueToDatetime(types.Boolean(true))
+			testutil.ErrorIs(t, err, ErrType)
+			testutil.Equals(t, v, types.Datetime{})
+		})
+
+	})
+
 	t.Run("Decimal", func(t *testing.T) {
 		t.Parallel()
 		t.Run("roundTrip", func(t *testing.T) {
@@ -161,6 +181,7 @@ func TestTypeName(t *testing.T) {
 	}{
 
 		{"boolean", types.Boolean(true), "bool"},
+		{"datetime", types.UnsafeDatetime(42), "datetime"},
 		{"decimal", types.UnsafeDecimal(42), "decimal"},
 		{"entityUID", types.NewEntityUID("T", "42"), "(entity of type `T`)"},
 		{"ip", types.IPAddr{}, "IP"},

--- a/internal/eval/util_test.go
+++ b/internal/eval/util_test.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/internal/testutil"
 	"github.com/cedar-policy/cedar-go/types"
@@ -181,7 +182,7 @@ func TestTypeName(t *testing.T) {
 	}{
 
 		{"boolean", types.Boolean(true), "bool"},
-		{"datetime", types.UnsafeDatetime(42), "datetime"},
+		{"datetime", types.FromStdTime(time.UnixMilli(42)), "datetime"},
 		{"decimal", types.UnsafeDecimal(42), "decimal"},
 		{"entityUID", types.NewEntityUID("T", "42"), "(entity of type `T`)"},
 		{"ip", types.IPAddr{}, "IP"},

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -11,6 +11,7 @@ var ExtMap = map[types.Path]extInfo{
 	"ip":       {Args: 1, IsMethod: false},
 	"decimal":  {Args: 1, IsMethod: false},
 	"datetime": {Args: 1, IsMethod: false},
+	"duration": {Args: 1, IsMethod: false},
 
 	"lessThan":           {Args: 2, IsMethod: true},
 	"lessThanOrEqual":    {Args: 2, IsMethod: true},
@@ -23,7 +24,16 @@ var ExtMap = map[types.Path]extInfo{
 	"isMulticast": {Args: 1, IsMethod: true},
 	"isInRange":   {Args: 2, IsMethod: true},
 
-	"toDate": {Args: 1, IsMethod: true},
+	"toDate":         {Args: 1, IsMethod: true},
+	"toTime":         {Args: 1, IsMethod: true},
+	"toDays":         {Args: 1, IsMethod: true},
+	"toHours":        {Args: 1, IsMethod: true},
+	"toMinutes":      {Args: 1, IsMethod: true},
+	"toSeconds":      {Args: 1, IsMethod: true},
+	"toMilliseconds": {Args: 1, IsMethod: true},
+
+	"offset":        {Args: 2, IsMethod: true},
+	"durationSince": {Args: 2, IsMethod: true},
 }
 
 func init() {

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -8,8 +8,9 @@ type extInfo struct {
 }
 
 var ExtMap = map[types.Path]extInfo{
-	"ip":      {Args: 1, IsMethod: false},
-	"decimal": {Args: 1, IsMethod: false},
+	"ip":       {Args: 1, IsMethod: false},
+	"decimal":  {Args: 1, IsMethod: false},
+	"datetime": {Args: 1, IsMethod: false},
 
 	"lessThan":           {Args: 2, IsMethod: true},
 	"lessThanOrEqual":    {Args: 2, IsMethod: true},
@@ -21,6 +22,8 @@ var ExtMap = map[types.Path]extInfo{
 	"isLoopback":  {Args: 1, IsMethod: true},
 	"isMulticast": {Args: 1, IsMethod: true},
 	"isInRange":   {Args: 2, IsMethod: true},
+
+	"toDate": {Args: 1, IsMethod: true},
 }
 
 func init() {

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestExtensions(t *testing.T) {
 	t.Parallel()
-	testutil.Equals(t, len(ExtMap), 13)
+	testutil.Equals(t, len(ExtMap), 22)
 }

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestExtensions(t *testing.T) {
 	t.Parallel()
-	testutil.Equals(t, len(ExtMap), 11)
+	testutil.Equals(t, len(ExtMap), 13)
 }

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -128,6 +128,6 @@ type nodeJSON struct {
 	// Record
 	Record recordJSON `json:"Record,omitempty"`
 
-	// Any other method: decimal, datetime, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
+	// Any other method: decimal, datetime, duration, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange, toDate, toTime, toDays, toHours, toMinutes, toSeconds, toMilliseconds, offset, durationSince
 	ExtensionCall extensionJSON `json:"-"`
 }

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -128,6 +128,6 @@ type nodeJSON struct {
 	// Record
 	Record recordJSON `json:"Record,omitempty"`
 
-	// Any other method: decimal, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
+	// Any other method: decimal, datetime, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
 	ExtensionCall extensionJSON `json:"-"`
 }

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,38 +10,48 @@ import (
 	"unicode"
 )
 
+// Datetime represents a Cedar datetime value
 type Datetime struct {
-	// Value is a timestamp in milliseconds
-	Value int64
+	// value is a timestamp in milliseconds
+	value int64
 }
 
-func UnsafeDatetime[T int | int64 | float64](v T) Datetime {
-	return Datetime{Value: int64(v)}
-}
-
+// FromStdTime returns a Cedar Datetime from a Go time.Time value
 func FromStdTime(t time.Time) Datetime {
-	return Datetime{Value: t.UnixMilli()}
+	return Datetime{value: t.UnixMilli()}
 }
 
-// "YYYY-MM-DD" (date only)
-// "YYYY-MM-DDThh:mm:ssZ" (UTC)
-// "YYYY-MM-DDThh:mm:ss.SSSZ" (UTC with millisecond precision)
-// "YYYY-MM-DDThh:mm:ss(+/-)hhmm" (With timezone offset in hours and minutes)
-// "YYYY-MM-DDThh:mm:ss.SSS(+/-)hhmm" (With timezone offset in hours and minutes and millisecond precision)
+// DatetimeFromMillis returns a Datetime from milliseconds
+func DatetimeFromMillis(ms int64) Datetime {
+	return Datetime{value: ms}
+}
+
+// ParseDatetime returns a Cedar datetime when the argument provided
+// represents a compatible datetime or an error
+//
+// Cedar RFC 80 defines valid datetime strings as one of:
+//
+// - "YYYY-MM-DD" (date only, with implied time 00:00:00, UTC)
+// - "YYYY-MM-DDThh:mm:ssZ" (date and time, UTC)
+// - "YYYY-MM-DDThh:mm:ss.SSSZ" (date and time with millisecond, UTC)
+// - "YYYY-MM-DDThh:mm:ss(+/-)hhmm" (date and time, time zone offset)
+// - "YYYY-MM-DDThh:mm:ss.SSS(+/-)hhmm" (date and time with millisecond, time zone offset)
 func ParseDatetime(s string) (Datetime, error) {
 	var (
 		year, month, day, hour, minute, second, milli int
-		i                                             int
+		offset                                        time.Duration
 	)
 
 	length := len(s)
-
 	if length < 10 {
 		return Datetime{}, fmt.Errorf("%w: string too short", ErrDatetime)
 	}
 
-	// parse YYYY-MM-DD
-
+	// Date: YYYY-MM-DD
+	// YYYY is at offset 0
+	// MM is at offset 5
+	// DD is at offset 8
+	// - is at 4 and 7
 	// YYYY
 	if !(unicode.IsDigit(rune(s[0])) &&
 		unicode.IsDigit(rune(s[1])) &&
@@ -48,225 +59,224 @@ func ParseDatetime(s string) (Datetime, error) {
 		unicode.IsDigit(rune(s[3]))) {
 		return Datetime{}, fmt.Errorf("%w: invalid year", ErrDatetime)
 	}
+	year = 1000*int(rune(s[0])-'0') +
+		100*int(rune(s[1])-'0') +
+		10*int(rune(s[2])-'0') +
+		int(rune(s[3])-'0')
 
-	year = 1000*int(rune(s[i])-'0') +
-		100*int(rune(s[i+1])-'0') +
-		10*int(rune(s[i+2])-'0') +
-		int(rune(s[i+3])-'0')
-
-	i = 4
-
-	c := rune(s[i])
-	if c != '-' {
-		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	if s[4] != '-' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(rune(s[4])))
 	}
-
-	i++
 
 	// MM
-	if !(unicode.IsDigit(rune(s[i])) &&
-		unicode.IsDigit(rune(s[i+1]))) {
+	if !(unicode.IsDigit(rune(s[5])) &&
+		unicode.IsDigit(rune(s[6]))) {
 		return Datetime{}, fmt.Errorf("%w: invalid month", ErrDatetime)
 	}
+	month = 10*int(rune(s[5])-'0') + int(rune(s[6])-'0')
 
-	month = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
-
-	i = i + 2
-
-	c = rune(s[i])
-	if c != '-' {
-		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	if s[7] != '-' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(rune(s[7])))
 	}
-
-	i++
 
 	// DD
-	if !(unicode.IsDigit(rune(s[i])) &&
-		unicode.IsDigit(rune(s[i+1]))) {
+	if !(unicode.IsDigit(rune(s[8])) &&
+		unicode.IsDigit(rune(s[9]))) {
 		return Datetime{}, fmt.Errorf("%w: invalid day", ErrDatetime)
 	}
+	day = 10*int(rune(s[8])-'0') + int(rune(s[9])-'0')
 
-	day = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
-
-	i = i + 2
-
-	if i == length { // done.
+	// If the length is 10, we only have a date and we're done.
+	if length == 10 {
 		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
-		return Datetime{Value: t.UnixMilli()}, nil
+		return Datetime{value: t.UnixMilli()}, nil
 	}
 
-	if length < 20 { // can't possibly have a well formed time.
+	// If the length is less than 20, we can't have a valid time.
+	if length < 20 {
 		return Datetime{}, fmt.Errorf("%w: invalid time", ErrDatetime)
 	}
 
-	// expect 'T'
-	c = rune(s[i])
-	if c != 'T' {
-		return Datetime{}, fmt.Errorf("%w: expected 'T'", ErrDatetime)
+	// Time: Thh:mm:ss?
+	// T is at 10
+	// hh is at offset 11
+	// mm is at offset 14
+	// ss is at offset 17
+	// : is at 13 and 16
+	// ? is at 19, and... we'll skip to get back to that.
+
+	if s[10] != 'T' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(rune(s[10])))
 	}
 
-	i++
-
-	// hh
-	if !(unicode.IsDigit(rune(s[i])) &&
-		unicode.IsDigit(rune(s[i+1]))) {
+	if !(unicode.IsDigit(rune(s[11])) &&
+		unicode.IsDigit(rune(s[12]))) {
 		return Datetime{}, fmt.Errorf("%w: invalid hour", ErrDatetime)
 	}
+	hour = 10*int(rune(s[11])-'0') + int(rune(s[12])-'0')
 
-	hour = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
-
-	i = i + 2
-
-	c = rune(s[i])
-	if c != ':' {
-		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	if s[13] != ':' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(rune(s[13])))
 	}
 
-	i++
-
-	// mm
-
-	if !(unicode.IsDigit(rune(s[i])) &&
-		unicode.IsDigit(rune(s[i+1]))) {
+	if !(unicode.IsDigit(rune(s[14])) &&
+		unicode.IsDigit(rune(s[15]))) {
 		return Datetime{}, fmt.Errorf("%w: invalid minute", ErrDatetime)
 	}
+	minute = 10*int(rune(s[14])-'0') + int(rune(s[15])-'0')
 
-	minute = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
-
-	i = i + 2
-
-	c = rune(s[i])
-	if c != ':' {
-		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	if s[16] != ':' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(rune(s[16])))
 	}
 
-	i++
-
-	// ss
-	if !(unicode.IsDigit(rune(s[i])) &&
-		unicode.IsDigit(rune(s[i+1]))) {
+	if !(unicode.IsDigit(rune(s[17])) &&
+		unicode.IsDigit(rune(s[18]))) {
 		return Datetime{}, fmt.Errorf("%w: invalid second", ErrDatetime)
 	}
+	second = 10*int(rune(s[17])-'0') + int(rune(s[18])-'0')
 
-	second = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
-
-	i += 2
-
-	// .SSS ??
-
-	c = rune(s[i])
-	if c == '.' {
-		i++
-
-		if i+3 > length {
+	// At this point, things are variable.
+	// 19 can be ., in which case we have milliseconds. (SSS)
+	//   ... but we'll still need a Z, or offset. So, we'll introduce
+	//       trailerOffset to account for where this starts.
+	trailerOffset := 19
+	if s[19] == '.' {
+		if length < 23 {
 			return Datetime{}, fmt.Errorf("%w: invalid millisecond", ErrDatetime)
 		}
 
-		if !(unicode.IsDigit(rune(s[i])) &&
-			unicode.IsDigit(rune(s[i+1])) &&
-			unicode.IsDigit(rune(s[i+2]))) {
+		if !(unicode.IsDigit(rune(s[20])) &&
+			unicode.IsDigit(rune(s[21])) &&
+			unicode.IsDigit(rune(s[22]))) {
 			return Datetime{}, fmt.Errorf("%w: invalid millisecond", ErrDatetime)
 		}
 
-		milli = 100*int(rune(s[i])-'0') + 10*int(rune(s[i+1])-'0') + int(rune(s[i+2])-'0')
-		i = i + 3
+		milli = 100*int(rune(s[20])-'0') + 10*int(rune(s[21])-'0') + int(rune(s[22])-'0')
+		trailerOffset = 23
 	}
 
-	if i >= length {
-		return Datetime{}, fmt.Errorf("%w: expected timezone indicator", ErrDatetime)
+	if length == trailerOffset {
+		return Datetime{}, fmt.Errorf("%w: expected time zone designator", ErrDatetime)
 	}
 
-	c = rune(s[i])
-	if c == 'Z' { // "YYYY-MM-DDThh:mm:ssZ"
-		if i+1 == length {
-			t := time.Date(year, time.Month(month),
-				day, hour, minute, second,
-				int(time.Duration(milli)*time.Millisecond), time.UTC)
-			return Datetime{Value: t.UnixMilli()}, nil
+	// At this point, we can only have 2 possible lengths. Anything else is an error.
+	switch s[trailerOffset] {
+	case 'Z':
+		if length > trailerOffset+1 {
+			// If something comes after the Z, it's an error
+			return Datetime{}, fmt.Errorf("%w: unexpected trailer after time zone designator", ErrDatetime)
 		}
-		return Datetime{}, fmt.Errorf("%w: unexpected trailer after timezone indicator", ErrDatetime)
+	case '+', '-':
+		sign := 1
+		if s[trailerOffset] == '-' {
+			sign = -1
+		}
+
+		if length > trailerOffset+5 {
+			return Datetime{}, fmt.Errorf("%w: unexpected trailer after time zone designator", ErrDatetime)
+		} else if length != trailerOffset+5 {
+			return Datetime{}, fmt.Errorf("%w: invalid time zone offset", ErrDatetime)
+		}
+
+		// get the time zone offset hhmm.
+		if !(unicode.IsDigit(rune(s[trailerOffset+1])) &&
+			unicode.IsDigit(rune(s[trailerOffset+2])) &&
+			unicode.IsDigit(rune(s[trailerOffset+3])) &&
+			unicode.IsDigit(rune(s[trailerOffset+4]))) {
+			return Datetime{}, fmt.Errorf("%w: invalid time zone offset", ErrDatetime)
+		}
+
+		hh := time.Duration(10*int64(rune(s[trailerOffset+1])-'0')+int64(rune(s[trailerOffset+2])-'0')) * time.Hour
+		mm := time.Duration(10*int64(rune(s[trailerOffset+3])-'0')+int64(rune(s[trailerOffset+4])-'0')) * time.Minute
+		offset = time.Duration(sign) * (hh + mm)
+
+	default:
+		return Datetime{}, fmt.Errorf("%w: invalid time zone designator", ErrDatetime)
 	}
-
-	// It must have an offset. +/-hhmm
-
-	if i+5 > length {
-		return Datetime{}, fmt.Errorf("%w: expected time offset", ErrDatetime)
-	} else if i+5 < length {
-		return Datetime{}, fmt.Errorf("%w: unexpected trailer", ErrDatetime)
-	}
-
-	sign := time.Duration(1)
-	c = rune(s[i])
-	if c == '-' {
-		sign = -sign
-	} else if c != '+' {
-		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
-	}
-
-	i++
-
-	if !(unicode.IsDigit(rune(s[i])) &&
-		unicode.IsDigit(rune(s[i+1])) &&
-		unicode.IsDigit(rune(s[i+2])) &&
-		unicode.IsDigit(rune(s[i+3]))) {
-		return Datetime{}, fmt.Errorf("%w: invalid time offset", ErrDatetime)
-	}
-
-	offsetH := time.Duration(10*int64(rune(s[i])-'0')+int64(rune(s[i+1])-'0')) * time.Hour
-	offsetM := time.Duration(10*int64(rune(s[i+2])-'0')+int64(rune(s[i+3])-'0')) * time.Minute
 
 	t := time.Date(year, time.Month(month), day,
 		hour, minute, second,
 		int(time.Duration(milli)*time.Millisecond), time.UTC)
-	t = t.Add(sign * (offsetH + offsetM))
-	return Datetime{Value: t.UnixMilli()}, nil
+	t = t.Add(offset)
+	return Datetime{value: t.UnixMilli()}, nil
 }
 
+// Equal returns true if the input represents the same timestamp.
 func (a Datetime) Equal(bi Value) bool {
 	b, ok := bi.(Datetime)
 	return ok && a == b
 }
 
-func (a Datetime) Less(bi Value) bool {
+// LessThan returns true if value is less than the argument and they
+// are both Datetime values, or an error indicating they aren't
+// comparable otherwise
+func (a Datetime) LessThan(bi Value) (bool, error) {
 	b, ok := bi.(Datetime)
-	return ok && a.Value < b.Value
+	if !ok {
+		return false, ErrNotComparable
+	}
+	return a.value < b.value, nil
 }
 
-func (a Datetime) LessEqual(bi Value) bool {
+// LessThan returns true if value is less than or equal to the
+// argument and they are both Datetime values, or an error indicating
+// they aren't comparable otherwise
+func (a Datetime) LessThanOrEqual(bi Value) (bool, error) {
 	b, ok := bi.(Datetime)
-	return ok && a.Value <= b.Value
+	if !ok {
+		return false, ErrNotComparable
+	}
+	return a.value <= b.value, nil
 }
 
+// MarshalCedar returns a []byte which, when parsed by the Cedar
+// Parser, returns an Equal Datetime value
 func (a Datetime) MarshalCedar() []byte {
 	return []byte(`datetime("` + a.String() + `")`)
 }
 
+// String returns an ISO 8601 millisecond precision timestamp
 func (a Datetime) String() string {
-	return time.UnixMilli(a.Value).UTC().Format("2006-01-02T15:04:05.000Z")
+	return time.UnixMilli(a.value).UTC().Format("2006-01-02T15:04:05.000Z")
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler for Datetime
+//
+// It is capable of unmarshaling 4 different representations supported by Cedar
+// - { "__extn": { "fn": "datetime", "arg": "1970-01-01" }}
+// - { "fn": "datetime", "arg": "1970-01-01" }
+// - "datetime(\"1970-01-01\")"
+// - "1970-01-01"
 func (a *Datetime) UnmarshalJSON(b []byte) error {
 	var arg string
-	if len(b) > 0 && b[0] == '"' {
+	if bytes.HasPrefix(b, []byte(`"datetime(\"`)) && bytes.HasSuffix(b, []byte(`\")"`)) {
+		arg = string(b[12 : len(b)-4])
+	} else if len(b) > 0 && b[0] == '"' {
 		if err := json.Unmarshal(b, &arg); err != nil {
 			return errors.Join(errJSONDecode, err)
 		}
 	} else {
-		// NOTE: cedar supports two other forms, for now we're only supporting the smallest implicit and explicit form.
-		// The following are not supported:
-		// "datetime(\"1970-01-01T00:00:00Z\")"
-		// {"fn":"datetime","arg":"1970-01-01T00:00:00Z"}
 		var res extValueJSON
 		if err := json.Unmarshal(b, &res); err != nil {
 			return errors.Join(errJSONDecode, err)
 		}
 		if res.Extn == nil {
-			return errJSONExtNotFound
-		}
-		if res.Extn.Fn != "datetime" {
+			// If we didn't find an Extn, maybe it's just an extn.
+			var res2 extn
+			json.Unmarshal(b, &res2)
+			// We've tried Ext.Fn and Fn, so no good.
+			if res2.Fn == "" {
+				return errJSONExtNotFound
+			}
+			if res2.Fn != "datetime" {
+				return errJSONExtFnMatch
+			}
+			arg = res2.Arg
+		} else if res.Extn.Fn != "datetime" {
 			return errJSONExtFnMatch
+		} else {
+			arg = res.Extn.Arg
 		}
-		arg = res.Extn.Arg
 	}
 	aa, err := ParseDatetime(arg)
 	if err != nil {
@@ -276,10 +286,15 @@ func (a *Datetime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the encoding/json.Marshaler interface
+//
+// It produces the direct representation of a Cedar Datetime.
 func (a Datetime) MarshalJSON() ([]byte, error) {
 	return []byte(`datetime("` + a.String() + `")`), nil
 }
 
+// ExplicitMarshalJSON Marshal's a Cedar Datetime with the explicit
+// representation
 func (a Datetime) ExplicitMarshalJSON() ([]byte, error) {
 	return json.Marshal(extValueJSON{
 		Extn: &extn{
@@ -287,6 +302,11 @@ func (a Datetime) ExplicitMarshalJSON() ([]byte, error) {
 			Arg: a.String(),
 		},
 	})
+}
+
+// Milliseconds returns the number of milliseconds since the Unix epoch
+func (a Datetime) Milliseconds() int64 {
+	return a.value
 }
 
 func (v Datetime) deepClone() Value { return v }

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -1,0 +1,292 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+	"unicode"
+)
+
+type Datetime struct {
+	// Value is a timestamp in milliseconds
+	Value int64
+}
+
+func UnsafeDatetime[T int | int64 | float64](v T) Datetime {
+	return Datetime{Value: int64(v)}
+}
+
+func FromStdTime(t time.Time) Datetime {
+	return Datetime{Value: t.UnixMilli()}
+}
+
+// "YYYY-MM-DD" (date only)
+// "YYYY-MM-DDThh:mm:ssZ" (UTC)
+// "YYYY-MM-DDThh:mm:ss.SSSZ" (UTC with millisecond precision)
+// "YYYY-MM-DDThh:mm:ss(+/-)hhmm" (With timezone offset in hours and minutes)
+// "YYYY-MM-DDThh:mm:ss.SSS(+/-)hhmm" (With timezone offset in hours and minutes and millisecond precision)
+func ParseDatetime(s string) (Datetime, error) {
+	var (
+		year, month, day, hour, minute, second, milli int
+		i                                             int
+	)
+
+	length := len(s)
+
+	if length < 10 {
+		return Datetime{}, fmt.Errorf("%w: string too short", ErrDatetime)
+	}
+
+	// parse YYYY-MM-DD
+
+	// YYYY
+	if !(unicode.IsDigit(rune(s[0])) &&
+		unicode.IsDigit(rune(s[1])) &&
+		unicode.IsDigit(rune(s[2])) &&
+		unicode.IsDigit(rune(s[3]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid year", ErrDatetime)
+	}
+
+	year = 1000*int(rune(s[i])-'0') +
+		100*int(rune(s[i+1])-'0') +
+		10*int(rune(s[i+2])-'0') +
+		int(rune(s[i+3])-'0')
+
+	i = 4
+
+	c := rune(s[i])
+	if c != '-' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// MM
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid month", ErrDatetime)
+	}
+
+	month = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	c = rune(s[i])
+	if c != '-' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// DD
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid day", ErrDatetime)
+	}
+
+	day = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	if i == length { // done.
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return Datetime{Value: t.UnixMilli()}, nil
+	}
+
+	if length < 20 { // can't possibly have a well formed time.
+		return Datetime{}, fmt.Errorf("%w: invalid time", ErrDatetime)
+	}
+
+	// expect 'T'
+	c = rune(s[i])
+	if c != 'T' {
+		return Datetime{}, fmt.Errorf("%w: expected 'T'", ErrDatetime)
+	}
+
+	i++
+
+	// hh
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid hour", ErrDatetime)
+	}
+
+	hour = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	c = rune(s[i])
+	if c != ':' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// mm
+
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid minute", ErrDatetime)
+	}
+
+	minute = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i = i + 2
+
+	c = rune(s[i])
+	if c != ':' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	// ss
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid second", ErrDatetime)
+	}
+
+	second = 10*int(rune(s[i])-'0') + int(rune(s[i+1])-'0')
+
+	i += 2
+
+	// .SSS ??
+
+	c = rune(s[i])
+	if c == '.' {
+		i++
+
+		if i+3 > length {
+			return Datetime{}, fmt.Errorf("%w: invalid millisecond", ErrDatetime)
+		}
+
+		if !(unicode.IsDigit(rune(s[i])) &&
+			unicode.IsDigit(rune(s[i+1])) &&
+			unicode.IsDigit(rune(s[i+2]))) {
+			return Datetime{}, fmt.Errorf("%w: invalid millisecond", ErrDatetime)
+		}
+
+		milli = 100*int(rune(s[i])-'0') + 10*int(rune(s[i+1])-'0') + int(rune(s[i+2])-'0')
+		i = i + 3
+	}
+
+	if i >= length {
+		return Datetime{}, fmt.Errorf("%w: expected timezone indicator", ErrDatetime)
+	}
+
+	c = rune(s[i])
+	if c == 'Z' { // "YYYY-MM-DDThh:mm:ssZ"
+		if i+1 == length {
+			t := time.Date(year, time.Month(month),
+				day, hour, minute, second,
+				int(time.Duration(milli)*time.Millisecond), time.UTC)
+			return Datetime{Value: t.UnixMilli()}, nil
+		}
+		return Datetime{}, fmt.Errorf("%w: unexpected trailer after timezone indicator", ErrDatetime)
+	}
+
+	// It must have an offset. +/-hhmm
+
+	if i+5 > length {
+		return Datetime{}, fmt.Errorf("%w: expected time offset", ErrDatetime)
+	} else if i+5 < length {
+		return Datetime{}, fmt.Errorf("%w: unexpected trailer", ErrDatetime)
+	}
+
+	sign := time.Duration(1)
+	c = rune(s[i])
+	if c == '-' {
+		sign = -sign
+	} else if c != '+' {
+		return Datetime{}, fmt.Errorf("%w: unexpected character %s", ErrDatetime, strconv.QuoteRune(c))
+	}
+
+	i++
+
+	if !(unicode.IsDigit(rune(s[i])) &&
+		unicode.IsDigit(rune(s[i+1])) &&
+		unicode.IsDigit(rune(s[i+2])) &&
+		unicode.IsDigit(rune(s[i+3]))) {
+		return Datetime{}, fmt.Errorf("%w: invalid time offset", ErrDatetime)
+	}
+
+	offsetH := time.Duration(10*int64(rune(s[i])-'0')+int64(rune(s[i+1])-'0')) * time.Hour
+	offsetM := time.Duration(10*int64(rune(s[i+2])-'0')+int64(rune(s[i+3])-'0')) * time.Minute
+
+	t := time.Date(year, time.Month(month), day,
+		hour, minute, second,
+		int(time.Duration(milli)*time.Millisecond), time.UTC)
+	t = t.Add(sign * (offsetH + offsetM))
+	return Datetime{Value: t.UnixMilli()}, nil
+}
+
+func (a Datetime) Equal(bi Value) bool {
+	b, ok := bi.(Datetime)
+	return ok && a == b
+}
+
+func (a Datetime) Less(bi Value) bool {
+	b, ok := bi.(Datetime)
+	return ok && a.Value < b.Value
+}
+
+func (a Datetime) LessEqual(bi Value) bool {
+	b, ok := bi.(Datetime)
+	return ok && a.Value <= b.Value
+}
+
+func (a Datetime) MarshalCedar() []byte {
+	return []byte(`datetime("` + a.String() + `")`)
+}
+
+func (a Datetime) String() string {
+	return time.UnixMilli(a.Value).UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+func (a *Datetime) UnmarshalJSON(b []byte) error {
+	var arg string
+	if len(b) > 0 && b[0] == '"' {
+		if err := json.Unmarshal(b, &arg); err != nil {
+			return errors.Join(errJSONDecode, err)
+		}
+	} else {
+		// NOTE: cedar supports two other forms, for now we're only supporting the smallest implicit and explicit form.
+		// The following are not supported:
+		// "datetime(\"1970-01-01T00:00:00Z\")"
+		// {"fn":"datetime","arg":"1970-01-01T00:00:00Z"}
+		var res extValueJSON
+		if err := json.Unmarshal(b, &res); err != nil {
+			return errors.Join(errJSONDecode, err)
+		}
+		if res.Extn == nil {
+			return errJSONExtNotFound
+		}
+		if res.Extn.Fn != "datetime" {
+			return errJSONExtFnMatch
+		}
+		arg = res.Extn.Arg
+	}
+	aa, err := ParseDatetime(arg)
+	if err != nil {
+		return err
+	}
+	*a = aa
+	return nil
+}
+
+func (a Datetime) MarshalJSON() ([]byte, error) {
+	return []byte(`datetime("` + a.String() + `")`), nil
+}
+
+func (a Datetime) ExplicitMarshalJSON() ([]byte, error) {
+	return json.Marshal(extValueJSON{
+		Extn: &extn{
+			Fn:  "datetime",
+			Arg: a.String(),
+		},
+	})
+}
+
+func (v Datetime) deepClone() Value { return v }

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -1,0 +1,123 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cedar-policy/cedar-go/internal/testutil"
+	"github.com/cedar-policy/cedar-go/types"
+)
+
+func TestDatetime(t *testing.T) {
+	t.Parallel()
+	{
+		tests := []struct{ in, out string }{
+			// date only YYYY-MM-DD
+			{"1970-01-01", "1970-01-01T00:00:00.000Z"},
+			{"1970-10-10", "1970-10-10T00:00:00.000Z"},
+			{"1970-11-11", "1970-11-11T00:00:00.000Z"},
+
+			// date and time only YYYY-MM-DDThh:mm:ssZ
+			{"1970-01-01T01:01:01Z", "1970-01-01T01:01:01.000Z"},
+			{"1970-01-01T10:10:10Z", "1970-01-01T10:10:10.000Z"},
+			{"1970-01-01T11:11:11Z", "1970-01-01T11:11:11.000Z"},
+
+			// date and time + milli only YYYY-MM-DDThh:mm:ss.SSSZ
+			{"1970-01-01T00:00:00.000Z", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T00:00:00.001Z", "1970-01-01T00:00:00.001Z"},
+			{"1970-01-01T00:00:00.011Z", "1970-01-01T00:00:00.011Z"},
+			{"1970-01-01T00:00:00.111Z", "1970-01-01T00:00:00.111Z"},
+			{"1970-01-01T00:00:00.010Z", "1970-01-01T00:00:00.010Z"},
+			{"1970-01-01T00:00:00.100Z", "1970-01-01T00:00:00.100Z"},
+
+			{"1970-01-01T00:00:00+0001", "1970-01-01T00:01:00.000Z"},
+			{"1970-01-01T00:00:00+0010", "1970-01-01T00:10:00.000Z"},
+			{"1970-01-01T00:00:00+0100", "1970-01-01T01:00:00.000Z"},
+			{"1970-01-01T00:00:00+1000", "1970-01-01T10:00:00.000Z"},
+
+			{"1970-01-01T00:01:00-0001", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T00:10:00-0010", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T01:00:00-0100", "1970-01-01T00:00:00.000Z"},
+			{"1970-01-01T10:00:00-1000", "1970-01-01T00:00:00.000Z"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.out), func(t *testing.T) {
+				t.Parallel()
+				d, err := types.ParseDatetime(tt.in)
+				testutil.OK(t, err)
+				testutil.Equals(t, d.String(), tt.out)
+			})
+		}
+	}
+
+	{
+		tests := []struct{ in, errStr string }{
+			{"", "error parsing datetime value: string too short"},
+			{"-", "error parsing datetime value: string too short"},
+			{"012345678", "error parsing datetime value: string too short"},
+
+			{"195-01-01T00:00:00Z", "error parsing datetime value: invalid year"},
+			{"1995-1-01T00:00:00Z", "error parsing datetime value: invalid month"},
+			{"1995-01-0T00:00:00Z", "error parsing datetime value: invalid day"},
+			{"1995-01T00:00:00Z", "error parsing datetime value: unexpected character 'T'"},
+			{"1995-01-01T:00:00Z", "error parsing datetime value: invalid time"},
+			{"1995-01-01Taa:00:00Z", "error parsing datetime value: invalid hour"},
+			{"1995-01-01T00:aa:00Z", "error parsing datetime value: invalid minute"},
+			{"1995-01-01T00:00:aaZ", "error parsing datetime value: invalid second"},
+			{"1995-01-01T00:00:00Zgarbage", "error parsing datetime value: unexpected trailer after timezone indicator"},
+			{"1995-01-01T00:00:00.", "error parsing datetime value: invalid millisecond"},
+			{"1995-01-01T00:00:00.0", "error parsing datetime value: invalid millisecond"},
+			{"1995-01-01T00:00:00.00", "error parsing datetime value: invalid millisecond"},
+			{"1995-01-01T00:00:00.aaa", "error parsing datetime value: invalid millisecond"},
+
+			{"1995-01-01T00:00:00.001", "error parsing datetime value: expected timezone indicator"},
+
+			{"1995-01-01T00:00:00.000Z+", "error parsing datetime value: unexpected trailer after timezone indicator"},
+			{"1995-01-01T00:00:00.000Z+0000", "error parsing datetime value: unexpected trailer after timezone indicator"},
+			{"1995-01-01T00:00:00.000Z+000", "error parsing datetime value: unexpected trailer after timezone indicator"},
+
+			{"1995-01-01T00:00:00.000+", "error parsing datetime value: expected time offset"},
+
+			{"1995-01-01T00:00:00.000+", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-", "error parsing datetime value: expected time offset"},
+
+			{"1995-01-01T00:00:00.000-0", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-00", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-000", "error parsing datetime value: expected time offset"},
+			{"1995-01-01T00:00:00.000-000a", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-00aa", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-0aaa", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-aaaa", "error parsing datetime value: invalid time offset"},
+			{"1995-01-01T00:00:00.000-aaaa0", "error parsing datetime value: unexpected trailer"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.errStr), func(t *testing.T) {
+				t.Parallel()
+				_, err := types.ParseDatetime(tt.in)
+				testutil.ErrorIs(t, err, types.ErrDatetime)
+				testutil.Equals(t, err.Error(), tt.errStr)
+			})
+		}
+	}
+
+	t.Run("Equal", func(t *testing.T) {
+		t.Parallel()
+		one := types.UnsafeDatetime(1)
+		one2 := types.UnsafeDatetime(1)
+		zero := types.UnsafeDatetime(0)
+		f := types.Boolean(false)
+		testutil.FatalIf(t, !one.Equal(one), "%v not Equal to %v", one, one)
+		testutil.FatalIf(t, !one.Equal(one2), "%v not Equal to %v", one, one2)
+		testutil.FatalIf(t, one.Equal(zero), "%v Equal to %v", one, zero)
+		testutil.FatalIf(t, zero.Equal(one), "%v Equal to %v", zero, one)
+		testutil.FatalIf(t, zero.Equal(f), "%v Equal to %v", zero, f)
+	})
+
+	t.Run("MarshalCedar", func(t *testing.T) {
+		t.Parallel()
+		testutil.Equals(t, string(types.UnsafeDatetime(42).MarshalCedar()), `datetime("1970-01-01T00:00:00.042Z")`)
+	})
+
+}

--- a/types/duration.go
+++ b/types/duration.go
@@ -1,0 +1,258 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+	"unicode"
+)
+
+const (
+	convertDays    int64 = 86400000
+	convertHours   int64 = 3600000
+	convertMinutes int64 = 60000
+	convertSeconds int64 = 1000
+)
+
+var unitToMillis = map[string]int64{
+	"d":  convertDays,
+	"h":  convertHours,
+	"m":  convertMinutes,
+	"s":  convertSeconds,
+	"ms": 1,
+}
+
+var unitOrder = []string{"d", "h", "m", "s", "ms"}
+
+// A Duration is a value representing a span of time in milliseconds.
+type Duration struct {
+	Value int64
+}
+
+// UnsafeDuration creates a duration via unsafe conversion from int, int64, float64
+func UnsafeDuration[T int | int64 | float64](v T) Duration {
+	return Duration{Value: int64(v)}
+}
+
+// FromStdDuration creates a duration from a Go stdlib time.Duration
+func FromStdDuration(d time.Duration) Duration {
+	return Duration{Value: d.Milliseconds()}
+}
+
+// ParseDuration takes a string representation of a duration and parses it into a Duration
+func ParseDuration(s string) (Duration, error) {
+	// Check for empty string.
+	if len(s) <= 1 {
+		return Duration{}, fmt.Errorf("%w: string too short", ErrDuration)
+	}
+
+	i := 0
+	unitI := 0
+
+	negative := int64(1)
+	if s[i] == '-' {
+		negative = int64(-1)
+		i++
+	}
+
+	var (
+		total    int64
+		value    int64
+		unit     string
+		hasValue bool
+	)
+
+	// ([0-9]+)(d|h|m|s|ms) ...
+
+	for i < len(s) && unitI < len(unitOrder) {
+		if unicode.IsDigit(rune(s[i])) {
+			value = value*10 + int64(s[i]-'0')
+
+			// check overflow
+			if value > math.MaxInt32 {
+				return Duration{}, fmt.Errorf("%w: overflow", ErrDuration)
+			}
+			hasValue = true
+			i++
+		} else if s[i] == 'd' || s[i] == 'h' || s[i] == 'm' || s[i] == 's' {
+			if !hasValue {
+				return Duration{}, fmt.Errorf("%w: unit found without quantity", ErrDuration)
+			}
+
+			// is it ms?
+			if s[i] == 'm' && i+1 < len(s) && s[i+1] == 's' {
+				unit = "ms"
+				i++
+			} else {
+				unit = s[i : i+1]
+			}
+
+			unitOK := false
+			for !unitOK && unitI < len(unitOrder) {
+				if unit == unitOrder[unitI] {
+					unitOK = true
+				}
+				unitI++
+			}
+
+			if !unitOK {
+				return Duration{}, fmt.Errorf("%w: unexpected unit '%s'", ErrDuration, unit)
+			}
+
+			total = total + value*unitToMillis[unit]
+			i++
+			hasValue = false
+			value = 0
+		} else {
+			return Duration{}, fmt.Errorf("%w: unexpected character %s", ErrDuration, strconv.QuoteRune(rune(s[i])))
+		}
+	}
+
+	// We didn't have a trailing unit
+	if hasValue {
+		return Duration{}, fmt.Errorf("%w: expected unit", ErrDuration)
+	}
+
+	// We still have characters left, but no more units to assign.
+	if i < len(s) {
+		return Duration{}, fmt.Errorf("%w: invalid duration", ErrDuration)
+	}
+
+	return Duration{Value: negative * total}, nil
+}
+
+func (a Duration) Equal(bi Value) bool {
+	b, ok := bi.(Duration)
+	return ok && a == b
+}
+
+func (a Duration) Less(bi Value) bool {
+	b, ok := bi.(Duration)
+	return ok && a.Value < b.Value
+}
+
+func (a Duration) LessEqual(bi Value) bool {
+	b, ok := bi.(Duration)
+	return ok && a.Value <= b.Value
+}
+
+// MarshalCedar produces a valid MarshalCedar language representation of the Duration, e.g. `decimal("12.34")`.
+func (v Duration) MarshalCedar() []byte { return []byte(`duration("` + v.String() + `")`) }
+
+// String produces a string representation of the Decimal, e.g. `12.34`.
+func (v Duration) String() string {
+	var res bytes.Buffer
+	if v.Value == 0 {
+		return "0ms"
+	}
+
+	remaining := v.Value
+	if v.Value < 0 {
+		remaining = -v.Value
+		res.WriteByte('-')
+	}
+
+	days := remaining / convertDays
+	if days > 0 {
+		res.WriteString(strconv.FormatInt(days, 10))
+		res.WriteByte('d')
+	}
+	remaining %= convertDays
+
+	hours := remaining / convertHours
+	if hours > 0 {
+		res.WriteString(strconv.FormatInt(hours, 10))
+		res.WriteByte('h')
+	}
+	remaining %= convertHours
+
+	minutes := remaining / convertMinutes
+	if minutes > 0 {
+		res.WriteString(strconv.FormatInt(minutes, 10))
+		res.WriteByte('m')
+	}
+	remaining %= convertMinutes
+
+	seconds := remaining / convertSeconds
+	if seconds > 0 {
+		res.WriteString(strconv.FormatInt(seconds, 10))
+		res.WriteByte('s')
+	}
+	remaining %= convertSeconds
+
+	if remaining > 0 {
+		res.WriteString(strconv.FormatInt(remaining, 10))
+		res.WriteString("ms")
+	}
+
+	return res.String()
+}
+
+func (v *Duration) UnmarshalJSON(b []byte) error {
+	var arg string
+	if len(b) > 0 && b[0] == '"' {
+		if err := json.Unmarshal(b, &arg); err != nil {
+			return errors.Join(errJSONDecode, err)
+		}
+	} else {
+		// NOTE: cedar supports two other forms, for now we're only supporting the smallest implicit and explicit form.
+		// The following are not supported:
+		// "duration(\"1d2h3m4s5ms\")"
+		// {"fn":"duration","arg":"1d2h3m4s5ms"}
+		var res extValueJSON
+		if err := json.Unmarshal(b, &res); err != nil {
+			return errors.Join(errJSONDecode, err)
+		}
+		if res.Extn == nil {
+			return errJSONExtNotFound
+		}
+		if res.Extn.Fn != "duration" {
+			return errJSONExtFnMatch
+		}
+		arg = res.Extn.Arg
+	}
+	vv, err := ParseDuration(arg)
+	if err != nil {
+		return err
+	}
+	*v = vv
+	return nil
+}
+
+// MarshalJSON marshals the Duration into JSON using the implicit form.
+func (v Duration) MarshalJSON() ([]byte, error) { return []byte(`"` + v.String() + `"`), nil }
+
+// ExplicitMarshalJSON marshals the Decimal into JSON using the explicit form.
+func (v Duration) ExplicitMarshalJSON() ([]byte, error) {
+	return json.Marshal(extValueJSON{
+		Extn: &extn{
+			Fn:  "duration",
+			Arg: v.String(),
+		},
+	})
+}
+func (v Duration) deepClone() Value { return v }
+
+func (v Duration) ToDays() int64 {
+	return v.Value / convertDays
+}
+
+func (v Duration) ToHours() int64 {
+	return v.Value / convertHours
+}
+
+func (v Duration) ToMinutes() int64 {
+	return v.Value / convertMinutes
+}
+
+func (v Duration) ToSeconds() int64 {
+	return v.Value / convertSeconds
+}
+
+func (v Duration) ToMilliseconds() int64 {
+	return v.Value
+}

--- a/types/duration.go
+++ b/types/duration.go
@@ -9,20 +9,15 @@ import (
 	"strconv"
 	"time"
 	"unicode"
-)
 
-const (
-	convertDays    int64 = 86400000
-	convertHours   int64 = 3600000
-	convertMinutes int64 = 60000
-	convertSeconds int64 = 1000
+	"github.com/cedar-policy/cedar-go/internal/consts"
 )
 
 var unitToMillis = map[string]int64{
-	"d":  convertDays,
-	"h":  convertHours,
-	"m":  convertMinutes,
-	"s":  convertSeconds,
+	"d":  consts.MillisPerDay,
+	"h":  consts.MillisPerHour,
+	"m":  consts.MillisPerMinute,
+	"s":  consts.MillisPerSecond,
 	"ms": 1,
 }
 
@@ -30,20 +25,30 @@ var unitOrder = []string{"d", "h", "m", "s", "ms"}
 
 // A Duration is a value representing a span of time in milliseconds.
 type Duration struct {
-	Value int64
+	value int64
 }
 
-// UnsafeDuration creates a duration via unsafe conversion from int, int64, float64
-func UnsafeDuration[T int | int64 | float64](v T) Duration {
-	return Duration{Value: int64(v)}
-}
-
-// FromStdDuration creates a duration from a Go stdlib time.Duration
+// FromStdDuration returns a Cedar Duration from a Go time.Duration
 func FromStdDuration(d time.Duration) Duration {
-	return Duration{Value: d.Milliseconds()}
+	return Duration{value: d.Milliseconds()}
 }
 
-// ParseDuration takes a string representation of a duration and parses it into a Duration
+// DurationFromMillis returns a Duration from milliseconds
+func DurationFromMillis(ms int64) Duration {
+	return Duration{value: ms}
+}
+
+// ParseDuration parses a Cedar Duration from a string
+//
+// Cedar RFC 80 defines a valid duration string as collapsed sequence
+// of quantity-unit pairs, possibly with a leading `-`, indicating a
+// negative duration.
+// The units must appear in order from longest timeframe to smallest.
+// - d: days
+// - h: hours
+// - m: minutes
+// - s: seconds
+// - ms: milliseconds
 func ParseDuration(s string) (Duration, error) {
 	// Check for empty string.
 	if len(s) <= 1 {
@@ -67,7 +72,6 @@ func ParseDuration(s string) (Duration, error) {
 	)
 
 	// ([0-9]+)(d|h|m|s|ms) ...
-
 	for i < len(s) && unitI < len(unitOrder) {
 		if unicode.IsDigit(rune(s[i])) {
 			value = value*10 + int64(s[i]-'0')
@@ -122,67 +126,80 @@ func ParseDuration(s string) (Duration, error) {
 		return Duration{}, fmt.Errorf("%w: invalid duration", ErrDuration)
 	}
 
-	return Duration{Value: negative * total}, nil
+	return Duration{value: negative * total}, nil
 }
 
+// Equal returns true if the input represents the same duration
 func (a Duration) Equal(bi Value) bool {
 	b, ok := bi.(Duration)
 	return ok && a == b
 }
 
-func (a Duration) Less(bi Value) bool {
+// LessThan returns true if value is less than the argument and they
+// are both Duration values, or an error indicating they aren't
+// comparable otherwise
+func (a Duration) LessThan(bi Value) (bool, error) {
 	b, ok := bi.(Duration)
-	return ok && a.Value < b.Value
+	if !ok {
+		return false, ErrNotComparable
+	}
+	return a.value < b.value, nil
 }
 
-func (a Duration) LessEqual(bi Value) bool {
+// LessThan returns true if value is less than or equal to the
+// argument and they are both Duration values, or an error indicating
+// they aren't comparable otherwise
+func (a Duration) LessThanOrEqual(bi Value) (bool, error) {
 	b, ok := bi.(Duration)
-	return ok && a.Value <= b.Value
+	if !ok {
+		return false, ErrNotComparable
+	}
+	return a.value <= b.value, nil
 }
 
 // MarshalCedar produces a valid MarshalCedar language representation of the Duration, e.g. `decimal("12.34")`.
 func (v Duration) MarshalCedar() []byte { return []byte(`duration("` + v.String() + `")`) }
 
-// String produces a string representation of the Decimal, e.g. `12.34`.
+// String produces a string representation of the Duration
 func (v Duration) String() string {
 	var res bytes.Buffer
-	if v.Value == 0 {
+	if v.value == 0 {
 		return "0ms"
 	}
 
-	remaining := v.Value
-	if v.Value < 0 {
-		remaining = -v.Value
+	remaining := v.value
+	if v.value < 0 {
+		remaining = -v.value
 		res.WriteByte('-')
 	}
 
-	days := remaining / convertDays
+	days := remaining / consts.MillisPerDay
 	if days > 0 {
 		res.WriteString(strconv.FormatInt(days, 10))
 		res.WriteByte('d')
 	}
-	remaining %= convertDays
+	remaining %= consts.MillisPerDay
 
-	hours := remaining / convertHours
+	hours := remaining / consts.MillisPerHour
 	if hours > 0 {
 		res.WriteString(strconv.FormatInt(hours, 10))
 		res.WriteByte('h')
 	}
-	remaining %= convertHours
+	remaining %= consts.MillisPerHour
 
-	minutes := remaining / convertMinutes
+	minutes := remaining / consts.MillisPerMinute
 	if minutes > 0 {
 		res.WriteString(strconv.FormatInt(minutes, 10))
 		res.WriteByte('m')
 	}
-	remaining %= convertMinutes
+	remaining %= consts.MillisPerMinute
 
-	seconds := remaining / convertSeconds
+	seconds := remaining / consts.MillisPerSecond
 	if seconds > 0 {
 		res.WriteString(strconv.FormatInt(seconds, 10))
 		res.WriteByte('s')
 	}
-	remaining %= convertSeconds
+	remaining %= consts.MillisPerSecond
 
 	if remaining > 0 {
 		res.WriteString(strconv.FormatInt(remaining, 10))
@@ -192,28 +209,43 @@ func (v Duration) String() string {
 	return res.String()
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler for Duration
+//
+// It is capable of unmarshaling 4 different representations supported by Cedar
+// - { "__extn": { "fn": "duration", "arg": "1h10m" }}
+// - { "fn": "duration", "arg": "1h10m" }
+// - "duration(\"1h10m\")"
+// - "1h10m"
 func (v *Duration) UnmarshalJSON(b []byte) error {
 	var arg string
-	if len(b) > 0 && b[0] == '"' {
+	if bytes.HasPrefix(b, []byte(`"duration(\"`)) && bytes.HasSuffix(b, []byte(`\")"`)) {
+		arg = string(b[12 : len(b)-4])
+	} else if len(b) > 0 && b[0] == '"' {
 		if err := json.Unmarshal(b, &arg); err != nil {
 			return errors.Join(errJSONDecode, err)
 		}
 	} else {
-		// NOTE: cedar supports two other forms, for now we're only supporting the smallest implicit and explicit form.
-		// The following are not supported:
-		// "duration(\"1d2h3m4s5ms\")"
-		// {"fn":"duration","arg":"1d2h3m4s5ms"}
 		var res extValueJSON
 		if err := json.Unmarshal(b, &res); err != nil {
 			return errors.Join(errJSONDecode, err)
 		}
 		if res.Extn == nil {
-			return errJSONExtNotFound
-		}
-		if res.Extn.Fn != "duration" {
+			// If we didn't find an Extn, maybe it's just an extn.
+			var res2 extn
+			json.Unmarshal(b, &res2)
+			// We've tried Ext.Fn and Fn, so no good.
+			if res2.Fn == "" {
+				return errJSONExtNotFound
+			}
+			if res2.Fn != "duration" {
+				return errJSONExtFnMatch
+			}
+			arg = res2.Arg
+		} else if res.Extn.Fn != "duration" {
 			return errJSONExtFnMatch
+		} else {
+			arg = res.Extn.Arg
 		}
-		arg = res.Extn.Arg
 	}
 	vv, err := ParseDuration(arg)
 	if err != nil {
@@ -237,22 +269,32 @@ func (v Duration) ExplicitMarshalJSON() ([]byte, error) {
 }
 func (v Duration) deepClone() Value { return v }
 
+// ToDays returns the number of days this Duration represents,
+// truncating when fractional
 func (v Duration) ToDays() int64 {
-	return v.Value / convertDays
+	return v.value / consts.MillisPerDay
 }
 
+// ToHours returns the number of hours this Duration represents,
+// truncating when fractional
 func (v Duration) ToHours() int64 {
-	return v.Value / convertHours
+	return v.value / consts.MillisPerHour
 }
 
+// ToMinutes returns the number of minutes this Duration represents,
+// truncating when fractional
 func (v Duration) ToMinutes() int64 {
-	return v.Value / convertMinutes
+	return v.value / consts.MillisPerMinute
 }
 
+// ToSeconds returns the number of seconds this Duration represents,
+// truncating when fractional
 func (v Duration) ToSeconds() int64 {
-	return v.Value / convertSeconds
+	return v.value / consts.MillisPerSecond
 }
 
+// ToMilliseconds returns the number of milliseconds this Duration
+// represents
 func (v Duration) ToMilliseconds() int64 {
-	return v.Value
+	return v.value
 }

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -1,0 +1,85 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cedar-policy/cedar-go/internal/testutil"
+	"github.com/cedar-policy/cedar-go/types"
+)
+
+func TestDuration(t *testing.T) {
+	t.Parallel()
+	{
+		tests := []struct{ in, out string }{
+			{"1h", "1h"},
+			{"60m", "1h"},
+			{"3600s", "1h"},
+			{"3600000ms", "1h"},
+			{"24h", "1d"},
+			{"36h", "1d12h"},
+			{"1d12h", "1d12h"},
+			{"1d11h60m", "1d12h"},
+			{"1d11h59m60s", "1d12h"},
+			{"1d11h59m59s1000ms", "1d12h"},
+			{"60s60000ms", "2m"},
+			{"62m", "1h2m"},
+			{"2m3600s", "1h2m"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.out), func(t *testing.T) {
+				t.Parallel()
+				d, err := types.ParseDuration(tt.in)
+				testutil.OK(t, err)
+				testutil.Equals(t, d.String(), tt.out)
+			})
+		}
+	}
+
+	{
+		tests := []struct{ in, errStr string }{
+			{"", "error parsing duration value: string too short"},
+			{"-", "error parsing duration value: string too short"},
+			{"h", "error parsing duration value: string too short"},
+			{"3", "error parsing duration value: string too short"},
+			{"-m", "error parsing duration value: unit found without quantity"},
+			{"-1t", "error parsing duration value: unexpected character 't'"},
+			{"-1h1h", "error parsing duration value: unexpected unit 'h'"},
+			{"-3h3", "error parsing duration value: expected unit"},
+			{"3h-1m", "error parsing duration value: unexpected character '-'"},
+			{"3h1m   ", "error parsing duration value: unexpected character ' '"},
+			{"3600ms30ms", "error parsing duration value: invalid duration"},
+			{"36ms30h", "error parsing duration value: invalid duration"},
+			{"999999999999999999999ms", "error parsing duration value: overflow"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.errStr), func(t *testing.T) {
+				t.Parallel()
+				_, err := types.ParseDuration(tt.in)
+				testutil.ErrorIs(t, err, types.ErrDuration)
+				testutil.Equals(t, err.Error(), tt.errStr)
+			})
+		}
+	}
+
+	t.Run("Equal", func(t *testing.T) {
+		t.Parallel()
+		one := types.UnsafeDuration(1)
+		one2 := types.UnsafeDuration(1)
+		zero := types.UnsafeDuration(0)
+		f := types.Boolean(false)
+		testutil.FatalIf(t, !one.Equal(one), "%v not Equal to %v", one, one)
+		testutil.FatalIf(t, !one.Equal(one2), "%v not Equal to %v", one, one2)
+		testutil.FatalIf(t, one.Equal(zero), "%v Equal to %v", one, zero)
+		testutil.FatalIf(t, zero.Equal(one), "%v Equal to %v", zero, one)
+		testutil.FatalIf(t, zero.Equal(f), "%v Equal to %v", zero, f)
+	})
+
+	t.Run("MarshalCedar", func(t *testing.T) {
+		t.Parallel()
+		testutil.Equals(t, string(types.UnsafeDuration(42).MarshalCedar()), `duration("42ms")`)
+	})
+
+}

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/internal/testutil"
 	"github.com/cedar-policy/cedar-go/types"
@@ -25,6 +26,19 @@ func TestDuration(t *testing.T) {
 			{"60s60000ms", "2m"},
 			{"62m", "1h2m"},
 			{"2m3600s", "1h2m"},
+			{"-1h", "-1h"},
+			{"-60m", "-1h"},
+			{"-3600s", "-1h"},
+			{"-3600000ms", "-1h"},
+			{"-24h", "-1d"},
+			{"-36h", "-1d12h"},
+			{"-1d12h", "-1d12h"},
+			{"-1d11h60m", "-1d12h"},
+			{"-1d11h59m60s", "-1d12h"},
+			{"-1d11h59m59s1000ms", "-1d12h"},
+			{"-60s60000ms", "-2m"},
+			{"-62m", "-1h2m"},
+			{"-2m3600s", "-1h2m"},
 		}
 		for ti, tt := range tests {
 			tt := tt
@@ -64,11 +78,18 @@ func TestDuration(t *testing.T) {
 		}
 	}
 
+	t.Run("Construct", func(t *testing.T) {
+		t.Parallel()
+		one := types.DurationFromMillis(1)
+		two := types.FromStdDuration(1 * time.Millisecond)
+		testutil.Equals(t, one.ToMilliseconds(), two.ToMilliseconds())
+	})
+
 	t.Run("Equal", func(t *testing.T) {
 		t.Parallel()
-		one := types.UnsafeDuration(1)
-		one2 := types.UnsafeDuration(1)
-		zero := types.UnsafeDuration(0)
+		one := types.DurationFromMillis(1)
+		one2 := types.FromStdDuration(1 * time.Millisecond)
+		zero := types.FromStdDuration(time.Duration(0))
 		f := types.Boolean(false)
 		testutil.FatalIf(t, !one.Equal(one), "%v not Equal to %v", one, one)
 		testutil.FatalIf(t, !one.Equal(one2), "%v not Equal to %v", one, one2)
@@ -77,9 +98,86 @@ func TestDuration(t *testing.T) {
 		testutil.FatalIf(t, zero.Equal(f), "%v Equal to %v", zero, f)
 	})
 
+	t.Run("LessThan", func(t *testing.T) {
+		t.Parallel()
+		one := types.FromStdDuration(1 * time.Millisecond)
+		zero := types.FromStdDuration(time.Duration(0))
+		f := types.Boolean(false)
+
+		tests := []struct {
+			l       types.Duration
+			r       types.Value
+			want    bool
+			wantErr error
+		}{
+			{one, zero, false, nil},
+			{zero, one, true, nil},
+			{zero, zero, false, nil},
+			{zero, f, false, types.ErrNotComparable},
+		}
+
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("LessThan_%d_%v<%v", ti, tt.l, tt.r), func(t *testing.T) {
+				t.Parallel()
+				got, gotErr := tt.l.LessThan(tt.r)
+				testutil.Equals(t, got, tt.want)
+				testutil.ErrorIs(t, gotErr, tt.wantErr)
+			})
+		}
+
+	})
+
+	t.Run("LessThanOrEqual", func(t *testing.T) {
+		t.Parallel()
+		one := types.FromStdDuration(1 * time.Millisecond)
+		zero := types.FromStdDuration(time.Duration(0))
+		f := types.Boolean(false)
+
+		tests := []struct {
+			l       types.Duration
+			r       types.Value
+			want    bool
+			wantErr error
+		}{
+			{one, zero, false, nil},
+			{zero, one, true, nil},
+			{zero, zero, true, nil},
+			{zero, f, false, types.ErrNotComparable},
+		}
+
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("LessThanOrEqual_%d_%v<%v", ti, tt.l, tt.r), func(t *testing.T) {
+				t.Parallel()
+				got, gotErr := tt.l.LessThanOrEqual(tt.r)
+				testutil.Equals(t, got, tt.want)
+				testutil.ErrorIs(t, gotErr, tt.wantErr)
+			})
+		}
+	})
+
+	t.Run("ToUnit", func(t *testing.T) {
+		t.Parallel()
+		dur := types.FromStdDuration((26 * time.Hour) + (31 * time.Minute) + (43 * time.Second) + (17 * time.Millisecond))
+
+		testutil.Equals(t, dur.ToDays(), 1)
+		testutil.Equals(t, dur.ToHours(), 26)
+		testutil.Equals(t, dur.ToMinutes(), 1591)
+		testutil.Equals(t, dur.ToSeconds(), 95503)
+		testutil.Equals(t, dur.ToMilliseconds(), 95503017)
+	})
+
 	t.Run("MarshalCedar", func(t *testing.T) {
 		t.Parallel()
-		testutil.Equals(t, string(types.UnsafeDuration(42).MarshalCedar()), `duration("42ms")`)
+		testutil.Equals(t, string(types.FromStdDuration(42*time.Millisecond).MarshalCedar()), `duration("42ms")`)
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		bs, err := types.FromStdDuration(42 * time.Millisecond).MarshalJSON()
+		testutil.OK(t, err)
+		testutil.Equals(t, string(bs), `"42ms"`)
 	})
 
 }

--- a/types/json.go
+++ b/types/json.go
@@ -75,6 +75,13 @@ func UnmarshalJSON(b []byte, v *Value) error {
 				}
 				*v = val
 				return nil
+			case "duration":
+				val, err := ParseDuration(res.Extn.Arg)
+				if err != nil {
+					return err
+				}
+				*v = val
+				return nil
 			default:
 				return errJSONInvalidExtn
 			}

--- a/types/json.go
+++ b/types/json.go
@@ -68,6 +68,13 @@ func UnmarshalJSON(b []byte, v *Value) error {
 				}
 				*v = val
 				return nil
+			case "datetime":
+				val, err := ParseDatetime(res.Extn.Arg)
+				if err != nil {
+					return err
+				}
+				*v = val
+				return nil
 			default:
 				return errJSONInvalidExtn
 			}

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -22,6 +22,11 @@ func mustDatetimeValue(v string) Datetime {
 	return r
 }
 
+func mustDurationValue(v string) Duration {
+	r, _ := ParseDuration(v)
+	return r
+}
+
 func mustIPValue(v string) IPAddr {
 	r, _ := ParseIPAddr(v)
 	return r
@@ -55,6 +60,7 @@ func TestJSON_Value(t *testing.T) {
 		{"explicitSubnet", `{ "__extn": { "fn": "ip", "arg": "192.168.0.0/16" } }`, mustIPValue("192.168.0.0/16"), nil},
 		{"explicitDecimal", `{ "__extn": { "fn": "decimal", "arg": "33.57" } }`, mustDecimalValue("33.57"), nil},
 		{"explicitDatetime", `{ "__extn": { "fn": "datetime", "arg": "1970-01-01T00:00:01Z" } }`, mustDatetimeValue("1970-01-01T00:00:01Z"), nil},
+		{"explicitDuration", `{ "__extn": { "fn": "duration", "arg": "1d12h30m30s500ms" } }`, mustDurationValue("1d12h30m30s500ms"), nil},
 		{"invalidExtension", `{ "__extn": { "fn": "asdf", "arg": "blah" } }`, zeroValue(), errJSONInvalidExtn},
 		{"badIP", `{ "__extn": { "fn": "ip", "arg": "bad" } }`, zeroValue(), ErrIP},
 		{"badDecimal", `{ "__extn": { "fn": "decimal", "arg": "bad" } }`, zeroValue(), ErrDecimal},

--- a/types/long.go
+++ b/types/long.go
@@ -13,14 +13,20 @@ func (a Long) Equal(bi Value) bool {
 	return ok && a == b
 }
 
-func (a Long) Less(bi Value) bool {
+func (a Long) LessThan(bi Value) (bool, error) {
 	b, ok := bi.(Long)
-	return ok && a < b
+	if !ok {
+		return false, ErrNotComparable
+	}
+	return a < b, nil
 }
 
-func (a Long) LessEqual(bi Value) bool {
+func (a Long) LessThanOrEqual(bi Value) (bool, error) {
 	b, ok := bi.(Long)
-	return ok && a <= b
+	if !ok {
+		return false, ErrNotComparable
+	}
+	return a <= b, nil
 }
 
 // ExplicitMarshalJSON marshals the Long into JSON.

--- a/types/long.go
+++ b/types/long.go
@@ -13,6 +13,16 @@ func (a Long) Equal(bi Value) bool {
 	return ok && a == b
 }
 
+func (a Long) Less(bi Value) bool {
+	b, ok := bi.(Long)
+	return ok && a < b
+}
+
+func (a Long) LessEqual(bi Value) bool {
+	b, ok := bi.(Long)
+	return ok && a <= b
+}
+
 // ExplicitMarshalJSON marshals the Long into JSON.
 func (v Long) ExplicitMarshalJSON() ([]byte, error) { return json.Marshal(v) }
 

--- a/types/long_test.go
+++ b/types/long_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cedar-policy/cedar-go/internal/testutil"
@@ -21,6 +22,65 @@ func TestLong(t *testing.T) {
 		testutil.FatalIf(t, one.Equal(zero), "%v Equal to %v", one, zero)
 		testutil.FatalIf(t, zero.Equal(one), "%v Equal to %v", zero, one)
 		testutil.FatalIf(t, zero.Equal(f), "%v Equal to %v", zero, f)
+	})
+
+	t.Run("LessThan", func(t *testing.T) {
+		t.Parallel()
+		one := types.Long(1)
+		zero := types.Long(0)
+		f := types.Boolean(false)
+
+		tests := []struct {
+			l       types.Long
+			r       types.Value
+			want    bool
+			wantErr error
+		}{
+			{one, zero, false, nil},
+			{zero, one, true, nil},
+			{zero, zero, false, nil},
+			{zero, f, false, types.ErrNotComparable},
+		}
+
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("LessThan_%d_%v<%v", ti, tt.l, tt.r), func(t *testing.T) {
+				t.Parallel()
+				got, gotErr := tt.l.LessThan(tt.r)
+				testutil.Equals(t, got, tt.want)
+				testutil.ErrorIs(t, gotErr, tt.wantErr)
+			})
+		}
+
+	})
+
+	t.Run("LessThanOrEqual", func(t *testing.T) {
+		t.Parallel()
+		one := types.Long(1)
+		zero := types.Long(0)
+		f := types.Boolean(false)
+
+		tests := []struct {
+			l       types.Long
+			r       types.Value
+			want    bool
+			wantErr error
+		}{
+			{one, zero, false, nil},
+			{zero, one, true, nil},
+			{zero, zero, true, nil},
+			{zero, f, false, types.ErrNotComparable},
+		}
+
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("LessThanOrEqual_%d_%v<%v", ti, tt.l, tt.r), func(t *testing.T) {
+				t.Parallel()
+				got, gotErr := tt.l.LessThanOrEqual(tt.r)
+				testutil.Equals(t, got, tt.want)
+				testutil.ErrorIs(t, gotErr, tt.wantErr)
+			})
+		}
 	})
 
 	t.Run("string", func(t *testing.T) {

--- a/types/value.go
+++ b/types/value.go
@@ -6,6 +6,7 @@ import (
 
 var ErrDatetime = fmt.Errorf("error parsing datetime value")
 var ErrDecimal = fmt.Errorf("error parsing decimal value")
+var ErrDuration = fmt.Errorf("error parsing duration value")
 var ErrIP = fmt.Errorf("error parsing ip value")
 
 // Value defines the interface for all Cedar values (String, Long, Set, Record, Boolean, etc ...)

--- a/types/value.go
+++ b/types/value.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+var ErrDatetime = fmt.Errorf("error parsing datetime value")
 var ErrDecimal = fmt.Errorf("error parsing decimal value")
 var ErrIP = fmt.Errorf("error parsing ip value")
 

--- a/types/value.go
+++ b/types/value.go
@@ -8,6 +8,7 @@ var ErrDatetime = fmt.Errorf("error parsing datetime value")
 var ErrDecimal = fmt.Errorf("error parsing decimal value")
 var ErrDuration = fmt.Errorf("error parsing duration value")
 var ErrIP = fmt.Errorf("error parsing ip value")
+var ErrNotComparable = fmt.Errorf("incompatible types in comparison")
 
 // Value defines the interface for all Cedar values (String, Long, Set, Record, Boolean, etc ...)
 type Value interface {

--- a/types/value_test.go
+++ b/types/value_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cedar-policy/cedar-go/internal/testutil"
 )
@@ -96,4 +97,25 @@ func TestDeepClone(t *testing.T) {
 		testutil.Equals(t, a.MarshalCedar(), mustIPValue("127.0.0.43").MarshalCedar())
 		testutil.Equals(t, b.MarshalCedar(), mustIPValue("127.0.0.42").MarshalCedar())
 	})
+
+	t.Run("Datetime", func(t *testing.T) {
+		t.Parallel()
+		a := FromStdTime(time.UnixMilli(42))
+		b := a.deepClone()
+		testutil.Equals(t, Value(a), b)
+		a = FromStdTime(time.UnixMilli(43))
+		testutil.Equals(t, a, FromStdTime(time.UnixMilli(43)))
+		testutil.Equals(t, b, Value(FromStdTime(time.UnixMilli(42))))
+	})
+
+	t.Run("Duration", func(t *testing.T) {
+		t.Parallel()
+		a := FromStdDuration(42 * time.Millisecond)
+		b := a.deepClone()
+		testutil.Equals(t, Value(a), b)
+		a = FromStdDuration(43 * time.Millisecond)
+		testutil.Equals(t, a, FromStdDuration(43*time.Millisecond))
+		testutil.Equals(t, b, Value(FromStdDuration(42*time.Millisecond)))
+	})
+
 }

--- a/types/virtual.go
+++ b/types/virtual.go
@@ -1,7 +1,0 @@
-package types
-
-type Lesser interface {
-	Value
-	Less(Value) bool
-	LessEqual(Value) bool
-}

--- a/types/virtual.go
+++ b/types/virtual.go
@@ -1,0 +1,7 @@
+package types
+
+type Lesser interface {
+	Value
+	Less(Value) bool
+	LessEqual(Value) bool
+}


### PR DESCRIPTION
See _pending_ [RFC 80](https://github.com/strongdm/cedar-rfcs/blob/datetime-rfc/text/0080-datetime-extension.md)

This PR adds operator overloading, by introducing a set of "Virtual"
comparison Evaler. Types that can overload operators must implement
the `Lesser` interface. Long, Datetime, and Duration are implemented in this
PR. (Note: It is expected that there will be a Decimal operator
overload RFC at some later date, but that is not hooked into this)

The now obsolete Evalers for Long comparisons have not been
removed. A possible improvement to this PR would be to utilize
them when it is known that Longs are on the right and left side.

The datetime itself is backed by an int64, and can be lifted from
a Go `time.Time`, or from integer and floats "unsafely." Duration, similarly, is backed by an int64, and can be lifted from a Go `time.Duration`, or from integer and floats "unsafely."