### PR TITLE
Add a duration type, as per RFC 80.

### DIFF
--- a/authorize_test.go
+++ b/authorize_test.go
@@ -561,6 +561,41 @@ func TestIsAuthorized(t *testing.T) {
 			DiagErr:   1,
 		},
 		{
+			Name: "permit-when-duration",
+			Policy: `permit(principal,action,resource) when {
+				duration("9h8m") < (duration("10h")) &&
+				duration("9h8m") <= (duration("10h")) &&
+				duration("9h8m") > (duration("7h")) &&
+				duration("9h8m") >= (duration("7h")) &&
+				duration("1ms").toMilliseconds() == 1 &&
+				duration("1s").toSeconds() == 1 &&
+				duration("1m").toMinutes() == 1 &&
+				duration("1h").toHours() == 1 &&
+				duration("1d").toDays() == 1 &&
+        datetime("1970-01-01").toTime() == duration("0ms") &&
+        datetime("1970-01-01").offset(duration("1ms")).toTime() == duration("1ms") &&
+        datetime("1970-01-01T00:00:00.001Z").durationSince(datetime("1970-01-01")) == duration("1ms")};`,
+
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      true,
+			DiagErr:   0,
+		},
+		{
+			Name:      "permit-when-duration-fun-wrong-arity",
+			Policy:    `permit(principal,action,resource) when { duration("1h", "huh?") };`,
+			Entities:  types.Entities{},
+			Principal: cuzco,
+			Action:    dropTable,
+			Resource:  types.NewEntityUID("table", "whatever"),
+			Context:   types.Record{},
+			Want:      false,
+			DiagErr:   1,
+		},
+		{
 			Name: "permit-when-ip",
 			Policy: `permit(principal,action,resource) when {
 				ip("1.2.3.4").isIpv4() &&

--- a/internal/eval/convert.go
+++ b/internal/eval/convert.go
@@ -38,6 +38,8 @@ func toEval(n ast.IsNode) Evaler {
 				return newDecimalLiteralEval(toEval(v.Args[0]))
 			case v.Name == "datetime":
 				return newDatetimeLiteralEval(toEval(v.Args[0]))
+			case v.Name == "duration":
+				return newDurationLiteralEval(toEval(v.Args[0]))
 
 			case v.Name == "lessThan":
 				return newDecimalLessThanEval(toEval(v.Args[0]), toEval(v.Args[1]))
@@ -61,6 +63,23 @@ func toEval(n ast.IsNode) Evaler {
 
 			case v.Name == "toDate":
 				return newToDateEval(toEval(v.Args[0]))
+			case v.Name == "toTime":
+				return newToTimeEval(toEval(v.Args[0]))
+			case v.Name == "toMilliseconds":
+				return newToMillisecondsEval(toEval(v.Args[0]))
+			case v.Name == "toSeconds":
+				return newToSecondsEval(toEval(v.Args[0]))
+			case v.Name == "toMinutes":
+				return newToMinutesEval(toEval(v.Args[0]))
+			case v.Name == "toHours":
+				return newToHoursEval(toEval(v.Args[0]))
+			case v.Name == "toDays":
+				return newToDaysEval(toEval(v.Args[0]))
+
+			case v.Name == "offset":
+				return newOffsetEval(toEval(v.Args[0]), toEval(v.Args[1]))
+			case v.Name == "durationSince":
+				return newDurationSinceEval(toEval(v.Args[0]), toEval(v.Args[1]))
 			}
 		}
 		return newErrorEval(fmt.Errorf("%w: %s", errUnknownExtensionFunction, v.Name))

--- a/internal/eval/convert_test.go
+++ b/internal/eval/convert_test.go
@@ -216,11 +216,66 @@ func TestToEval(t *testing.T) {
 			testutil.OK,
 		},
 		{
+			"duration",
+			ast.ExtensionCall("duration", ast.String("1ms")),
+			types.UnsafeDuration(1),
+			testutil.OK,
+		},
+		{
 			"toDate",
 			ast.ExtensionCall("toDate", ast.Value(types.UnsafeDatetime(1))),
 			types.UnsafeDatetime(0),
 			testutil.OK,
 		},
+		{
+			"toTime",
+			ast.ExtensionCall("toTime", ast.Value(types.UnsafeDatetime(1))),
+			types.UnsafeDuration(1),
+			testutil.OK,
+		},
+		{
+			"toDays",
+			ast.ExtensionCall("toDays", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toHours",
+			ast.ExtensionCall("toHours", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toMinutes",
+			ast.ExtensionCall("toMinutes", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toSeconds",
+			ast.ExtensionCall("toSeconds", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"toMilliseconds",
+			ast.ExtensionCall("toMilliseconds", ast.Value(types.UnsafeDuration(0))),
+			types.Long(0),
+			testutil.OK,
+		},
+		{
+			"offset",
+			ast.ExtensionCall("offset", ast.Value(types.UnsafeDatetime(0)), ast.Value(types.UnsafeDuration(1))),
+			types.UnsafeDatetime(1),
+			testutil.OK,
+		},
+		{
+			"durationSince",
+			ast.ExtensionCall("durationSince", ast.Value(types.UnsafeDatetime(1)), ast.Value(types.UnsafeDatetime(1))),
+			types.UnsafeDuration(0),
+			testutil.OK,
+		},
+
 		{
 			"lessThan",
 			ast.ExtensionCall("lessThan", ast.Value(types.UnsafeDecimal(42.0)), ast.Value(types.UnsafeDecimal(43))),

--- a/internal/eval/util.go
+++ b/internal/eval/util.go
@@ -97,6 +97,14 @@ func ValueToDecimal(v types.Value) (types.Decimal, error) {
 	return d, nil
 }
 
+func ValueToDuration(v types.Value) (types.Duration, error) {
+	d, ok := v.(types.Duration)
+	if !ok {
+		return types.Duration{}, fmt.Errorf("%w: expected duration, got %v", ErrType, TypeName(v))
+	}
+	return d, nil
+}
+
 func ValueToIP(v types.Value) (types.IPAddr, error) {
 	i, ok := v.(types.IPAddr)
 	if !ok {

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -11,6 +11,7 @@ var ExtMap = map[types.Path]extInfo{
 	"ip":       {Args: 1, IsMethod: false},
 	"decimal":  {Args: 1, IsMethod: false},
 	"datetime": {Args: 1, IsMethod: false},
+	"duration": {Args: 1, IsMethod: false},
 
 	"lessThan":           {Args: 2, IsMethod: true},
 	"lessThanOrEqual":    {Args: 2, IsMethod: true},
@@ -23,7 +24,16 @@ var ExtMap = map[types.Path]extInfo{
 	"isMulticast": {Args: 1, IsMethod: true},
 	"isInRange":   {Args: 2, IsMethod: true},
 
-	"toDate": {Args: 1, IsMethod: true},
+	"toDate":         {Args: 1, IsMethod: true},
+	"toTime":         {Args: 1, IsMethod: true},
+	"toDays":         {Args: 1, IsMethod: true},
+	"toHours":        {Args: 1, IsMethod: true},
+	"toMinutes":      {Args: 1, IsMethod: true},
+	"toSeconds":      {Args: 1, IsMethod: true},
+	"toMilliseconds": {Args: 1, IsMethod: true},
+
+	"offset":        {Args: 2, IsMethod: true},
+	"durationSince": {Args: 2, IsMethod: true},
 }
 
 func init() {

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestExtensions(t *testing.T) {
 	t.Parallel()
-	testutil.Equals(t, len(ExtMap), 13)
+	testutil.Equals(t, len(ExtMap), 22)
 }

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -128,6 +128,6 @@ type nodeJSON struct {
 	// Record
 	Record recordJSON `json:"Record,omitempty"`
 
-	// Any other method: decimal, datetime, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange
+	// Any other method: decimal, datetime, duration, ip, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, isIpv4, isIpv6, isLoopback, isMulticast, isInRange, toDate, toTime, toDays, toHours, toMinutes, toSeconds, toMilliseconds, offset, durationSince
 	ExtensionCall extensionJSON `json:"-"`
 }

--- a/types/duration.go
+++ b/types/duration.go
@@ -1,0 +1,258 @@
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+	"unicode"
+)
+
+const (
+	convertDays    int64 = 86400000
+	convertHours   int64 = 3600000
+	convertMinutes int64 = 60000
+	convertSeconds int64 = 1000
+)
+
+var unitToMillis = map[string]int64{
+	"d":  convertDays,
+	"h":  convertHours,
+	"m":  convertMinutes,
+	"s":  convertSeconds,
+	"ms": 1,
+}
+
+var unitOrder = []string{"d", "h", "m", "s", "ms"}
+
+// A Duration is a value representing a span of time in milliseconds.
+type Duration struct {
+	Value int64
+}
+
+// UnsafeDuration creates a duration via unsafe conversion from int, int64, float64
+func UnsafeDuration[T int | int64 | float64](v T) Duration {
+	return Duration{Value: int64(v)}
+}
+
+// FromStdDuration creates a duration from a Go stdlib time.Duration
+func FromStdDuration(d time.Duration) Duration {
+	return Duration{Value: d.Milliseconds()}
+}
+
+// ParseDuration takes a string representation of a duration and parses it into a Duration
+func ParseDuration(s string) (Duration, error) {
+	// Check for empty string.
+	if len(s) <= 1 {
+		return Duration{}, fmt.Errorf("%w: string too short", ErrDuration)
+	}
+
+	i := 0
+	unitI := 0
+
+	negative := int64(1)
+	if s[i] == '-' {
+		negative = int64(-1)
+		i++
+	}
+
+	var (
+		total    int64
+		value    int64
+		unit     string
+		hasValue bool
+	)
+
+	// ([0-9]+)(d|h|m|s|ms) ...
+
+	for i < len(s) && unitI < len(unitOrder) {
+		if unicode.IsDigit(rune(s[i])) {
+			value = value*10 + int64(s[i]-'0')
+
+			// check overflow
+			if value > math.MaxInt32 {
+				return Duration{}, fmt.Errorf("%w: overflow", ErrDuration)
+			}
+			hasValue = true
+			i++
+		} else if s[i] == 'd' || s[i] == 'h' || s[i] == 'm' || s[i] == 's' {
+			if !hasValue {
+				return Duration{}, fmt.Errorf("%w: unit found without quantity", ErrDuration)
+			}
+
+			// is it ms?
+			if s[i] == 'm' && i+1 < len(s) && s[i+1] == 's' {
+				unit = "ms"
+				i++
+			} else {
+				unit = s[i : i+1]
+			}
+
+			unitOK := false
+			for !unitOK && unitI < len(unitOrder) {
+				if unit == unitOrder[unitI] {
+					unitOK = true
+				}
+				unitI++
+			}
+
+			if !unitOK {
+				return Duration{}, fmt.Errorf("%w: unexpected unit '%s'", ErrDuration, unit)
+			}
+
+			total = total + value*unitToMillis[unit]
+			i++
+			hasValue = false
+			value = 0
+		} else {
+			return Duration{}, fmt.Errorf("%w: unexpected character %s", ErrDuration, strconv.QuoteRune(rune(s[i])))
+		}
+	}
+
+	// We didn't have a trailing unit
+	if hasValue {
+		return Duration{}, fmt.Errorf("%w: expected unit", ErrDuration)
+	}
+
+	// We still have characters left, but no more units to assign.
+	if i < len(s) {
+		return Duration{}, fmt.Errorf("%w: invalid duration", ErrDuration)
+	}
+
+	return Duration{Value: negative * total}, nil
+}
+
+func (a Duration) Equal(bi Value) bool {
+	b, ok := bi.(Duration)
+	return ok && a == b
+}
+
+func (a Duration) Less(bi Value) bool {
+	b, ok := bi.(Duration)
+	return ok && a.Value < b.Value
+}
+
+func (a Duration) LessEqual(bi Value) bool {
+	b, ok := bi.(Duration)
+	return ok && a.Value <= b.Value
+}
+
+// MarshalCedar produces a valid MarshalCedar language representation of the Duration, e.g. `decimal("12.34")`.
+func (v Duration) MarshalCedar() []byte { return []byte(`duration("` + v.String() + `")`) }
+
+// String produces a string representation of the Decimal, e.g. `12.34`.
+func (v Duration) String() string {
+	var res bytes.Buffer
+	if v.Value == 0 {
+		return "0ms"
+	}
+
+	remaining := v.Value
+	if v.Value < 0 {
+		remaining = -v.Value
+		res.WriteByte('-')
+	}
+
+	days := remaining / convertDays
+	if days > 0 {
+		res.WriteString(strconv.FormatInt(days, 10))
+		res.WriteByte('d')
+	}
+	remaining %= convertDays
+
+	hours := remaining / convertHours
+	if hours > 0 {
+		res.WriteString(strconv.FormatInt(hours, 10))
+		res.WriteByte('h')
+	}
+	remaining %= convertHours
+
+	minutes := remaining / convertMinutes
+	if minutes > 0 {
+		res.WriteString(strconv.FormatInt(minutes, 10))
+		res.WriteByte('m')
+	}
+	remaining %= convertMinutes
+
+	seconds := remaining / convertSeconds
+	if seconds > 0 {
+		res.WriteString(strconv.FormatInt(seconds, 10))
+		res.WriteByte('s')
+	}
+	remaining %= convertSeconds
+
+	if remaining > 0 {
+		res.WriteString(strconv.FormatInt(remaining, 10))
+		res.WriteString("ms")
+	}
+
+	return res.String()
+}
+
+func (v *Duration) UnmarshalJSON(b []byte) error {
+	var arg string
+	if len(b) > 0 && b[0] == '"' {
+		if err := json.Unmarshal(b, &arg); err != nil {
+			return errors.Join(errJSONDecode, err)
+		}
+	} else {
+		// NOTE: cedar supports two other forms, for now we're only supporting the smallest implicit and explicit form.
+		// The following are not supported:
+		// "duration(\"1d2h3m4s5ms\")"
+		// {"fn":"duration","arg":"1d2h3m4s5ms"}
+		var res extValueJSON
+		if err := json.Unmarshal(b, &res); err != nil {
+			return errors.Join(errJSONDecode, err)
+		}
+		if res.Extn == nil {
+			return errJSONExtNotFound
+		}
+		if res.Extn.Fn != "duration" {
+			return errJSONExtFnMatch
+		}
+		arg = res.Extn.Arg
+	}
+	vv, err := ParseDuration(arg)
+	if err != nil {
+		return err
+	}
+	*v = vv
+	return nil
+}
+
+// MarshalJSON marshals the Duration into JSON using the implicit form.
+func (v Duration) MarshalJSON() ([]byte, error) { return []byte(`"` + v.String() + `"`), nil }
+
+// ExplicitMarshalJSON marshals the Decimal into JSON using the explicit form.
+func (v Duration) ExplicitMarshalJSON() ([]byte, error) {
+	return json.Marshal(extValueJSON{
+		Extn: &extn{
+			Fn:  "duration",
+			Arg: v.String(),
+		},
+	})
+}
+func (v Duration) deepClone() Value { return v }
+
+func (v Duration) ToDays() int64 {
+	return v.Value / convertDays
+}
+
+func (v Duration) ToHours() int64 {
+	return v.Value / convertHours
+}
+
+func (v Duration) ToMinutes() int64 {
+	return v.Value / convertMinutes
+}
+
+func (v Duration) ToSeconds() int64 {
+	return v.Value / convertSeconds
+}
+
+func (v Duration) ToMilliseconds() int64 {
+	return v.Value
+}

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -1,0 +1,85 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cedar-policy/cedar-go/internal/testutil"
+	"github.com/cedar-policy/cedar-go/types"
+)
+
+func TestDuration(t *testing.T) {
+	t.Parallel()
+	{
+		tests := []struct{ in, out string }{
+			{"1h", "1h"},
+			{"60m", "1h"},
+			{"3600s", "1h"},
+			{"3600000ms", "1h"},
+			{"24h", "1d"},
+			{"36h", "1d12h"},
+			{"1d12h", "1d12h"},
+			{"1d11h60m", "1d12h"},
+			{"1d11h59m60s", "1d12h"},
+			{"1d11h59m59s1000ms", "1d12h"},
+			{"60s60000ms", "2m"},
+			{"62m", "1h2m"},
+			{"2m3600s", "1h2m"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.out), func(t *testing.T) {
+				t.Parallel()
+				d, err := types.ParseDuration(tt.in)
+				testutil.OK(t, err)
+				testutil.Equals(t, d.String(), tt.out)
+			})
+		}
+	}
+
+	{
+		tests := []struct{ in, errStr string }{
+			{"", "error parsing duration value: string too short"},
+			{"-", "error parsing duration value: string too short"},
+			{"h", "error parsing duration value: string too short"},
+			{"3", "error parsing duration value: string too short"},
+			{"-m", "error parsing duration value: unit found without quantity"},
+			{"-1t", "error parsing duration value: unexpected character 't'"},
+			{"-1h1h", "error parsing duration value: unexpected unit 'h'"},
+			{"-3h3", "error parsing duration value: expected unit"},
+			{"3h-1m", "error parsing duration value: unexpected character '-'"},
+			{"3h1m   ", "error parsing duration value: unexpected character ' '"},
+			{"3600ms30ms", "error parsing duration value: invalid duration"},
+			{"36ms30h", "error parsing duration value: invalid duration"},
+			{"999999999999999999999ms", "error parsing duration value: overflow"},
+		}
+		for ti, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%d_%s->%s", ti, tt.in, tt.errStr), func(t *testing.T) {
+				t.Parallel()
+				_, err := types.ParseDuration(tt.in)
+				testutil.ErrorIs(t, err, types.ErrDuration)
+				testutil.Equals(t, err.Error(), tt.errStr)
+			})
+		}
+	}
+
+	t.Run("Equal", func(t *testing.T) {
+		t.Parallel()
+		one := types.UnsafeDuration(1)
+		one2 := types.UnsafeDuration(1)
+		zero := types.UnsafeDuration(0)
+		f := types.Boolean(false)
+		testutil.FatalIf(t, !one.Equal(one), "%v not Equal to %v", one, one)
+		testutil.FatalIf(t, !one.Equal(one2), "%v not Equal to %v", one, one2)
+		testutil.FatalIf(t, one.Equal(zero), "%v Equal to %v", one, zero)
+		testutil.FatalIf(t, zero.Equal(one), "%v Equal to %v", zero, one)
+		testutil.FatalIf(t, zero.Equal(f), "%v Equal to %v", zero, f)
+	})
+
+	t.Run("MarshalCedar", func(t *testing.T) {
+		t.Parallel()
+		testutil.Equals(t, string(types.UnsafeDuration(42).MarshalCedar()), `duration("42ms")`)
+	})
+
+}

--- a/types/json.go
+++ b/types/json.go
@@ -75,6 +75,13 @@ func UnmarshalJSON(b []byte, v *Value) error {
 				}
 				*v = val
 				return nil
+			case "duration":
+				val, err := ParseDuration(res.Extn.Arg)
+				if err != nil {
+					return err
+				}
+				*v = val
+				return nil
 			default:
 				return errJSONInvalidExtn
 			}

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -22,6 +22,11 @@ func mustDatetimeValue(v string) Datetime {
 	return r
 }
 
+func mustDurationValue(v string) Duration {
+	r, _ := ParseDuration(v)
+	return r
+}
+
 func mustIPValue(v string) IPAddr {
 	r, _ := ParseIPAddr(v)
 	return r
@@ -55,6 +60,7 @@ func TestJSON_Value(t *testing.T) {
 		{"explicitSubnet", `{ "__extn": { "fn": "ip", "arg": "192.168.0.0/16" } }`, mustIPValue("192.168.0.0/16"), nil},
 		{"explicitDecimal", `{ "__extn": { "fn": "decimal", "arg": "33.57" } }`, mustDecimalValue("33.57"), nil},
 		{"explicitDatetime", `{ "__extn": { "fn": "datetime", "arg": "1970-01-01T00:00:01Z" } }`, mustDatetimeValue("1970-01-01T00:00:01Z"), nil},
+		{"explicitDuration", `{ "__extn": { "fn": "duration", "arg": "1d12h30m30s500ms" } }`, mustDurationValue("1d12h30m30s500ms"), nil},
 		{"invalidExtension", `{ "__extn": { "fn": "asdf", "arg": "blah" } }`, zeroValue(), errJSONInvalidExtn},
 		{"badIP", `{ "__extn": { "fn": "ip", "arg": "bad" } }`, zeroValue(), ErrIP},
 		{"badDecimal", `{ "__extn": { "fn": "decimal", "arg": "bad" } }`, zeroValue(), ErrDecimal},

--- a/types/value.go
+++ b/types/value.go
@@ -6,6 +6,7 @@ import (
 
 var ErrDatetime = fmt.Errorf("error parsing datetime value")
 var ErrDecimal = fmt.Errorf("error parsing decimal value")
+var ErrDuration = fmt.Errorf("error parsing duration value")
 var ErrIP = fmt.Errorf("error parsing ip value")
 
 // Value defines the interface for all Cedar values (String, Long, Set, Record, Boolean, etc ...)


### PR DESCRIPTION
This builds on the Datetime PR.

It adds the duration type, and all of the associated methods that require durations:

- datetime.toTime
- datetime.offset
- datetime.durationSince
- duration.toMilliseconds
- duration.toSeconds
- duration.toMinutes
- duration.toHours
- duration.toDays