### PR TITLE
RFC: types: Invert the special casing of JSON marshaling for Value

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,6 +1,8 @@
 package json
 
 import (
+	"encoding/json"
+
 	"github.com/cedar-policy/cedar-go/types"
 )
 
@@ -13,16 +15,18 @@ type policyJSON struct {
 	Conditions  []conditionJSON   `json:"conditions,omitempty"`
 }
 
+// scopeInJSON uses the implicit form of EntityUID JSON serialization to match the Rust SDK
 type scopeInJSON struct {
-	Entity types.EntityUID `json:"entity"`
+	Entity types.ImplicitlyMarshaledEntityUID `json:"entity"`
 }
 
+// scopeJSON uses the implicit form of EntityUID JSON serialization to match the Rust SDK
 type scopeJSON struct {
-	Op         string            `json:"op"`
-	Entity     *types.EntityUID  `json:"entity,omitempty"`
-	Entities   []types.EntityUID `json:"entities,omitempty"`
-	EntityType string            `json:"entity_type,omitempty"`
-	In         *scopeInJSON      `json:"in,omitempty"`
+	Op         string                               `json:"op"`
+	Entity     *types.ImplicitlyMarshaledEntityUID  `json:"entity,omitempty"`
+	Entities   []types.ImplicitlyMarshaledEntityUID `json:"entities,omitempty"`
+	EntityType string                               `json:"entity_type,omitempty"`
+	In         *scopeInJSON                         `json:"in,omitempty"`
 }
 
 type conditionJSON struct {
@@ -72,8 +76,9 @@ type valueJSON struct {
 }
 
 func (e *valueJSON) MarshalJSON() ([]byte, error) {
-	return e.v.ExplicitMarshalJSON()
+	return json.Marshal(e.v)
 }
+
 func (e *valueJSON) UnmarshalJSON(b []byte) error {
 	return types.UnmarshalJSON(b, &e.v)
 }

--- a/internal/json/json_marshal.go
+++ b/internal/json/json_marshal.go
@@ -15,17 +15,21 @@ func (s *scopeJSON) FromNode(src ast.IsScopeNode) {
 		return
 	case ast.ScopeTypeEq:
 		s.Op = "=="
-		e := t.Entity
+		e := types.ImplicitlyMarshaledEntityUID(t.Entity)
 		s.Entity = &e
 		return
 	case ast.ScopeTypeIn:
 		s.Op = "in"
-		e := t.Entity
+		e := types.ImplicitlyMarshaledEntityUID(t.Entity)
 		s.Entity = &e
 		return
 	case ast.ScopeTypeInSet:
 		s.Op = "in"
-		s.Entities = t.Entities
+		es := make([]types.ImplicitlyMarshaledEntityUID, len(t.Entities))
+		for i, e := range t.Entities {
+			es[i] = types.ImplicitlyMarshaledEntityUID(e)
+		}
+		s.Entities = es
 		return
 	case ast.ScopeTypeIs:
 		s.Op = "is"
@@ -35,7 +39,7 @@ func (s *scopeJSON) FromNode(src ast.IsScopeNode) {
 		s.Op = "is"
 		s.EntityType = string(t.Type)
 		s.In = &scopeInJSON{
-			Entity: t.Entity,
+			Entity: types.ImplicitlyMarshaledEntityUID(t.Entity),
 		}
 		return
 	default:

--- a/internal/json/json_unmarshal.go
+++ b/internal/json/json_unmarshal.go
@@ -25,17 +25,17 @@ func (s *scopeJSON) ToPrincipalResourceNode() (isPrincipalResourceScopeNode, err
 		if s.Entity == nil {
 			return nil, fmt.Errorf("missing entity")
 		}
-		return ast.Scope{}.Eq(*s.Entity), nil
+		return ast.Scope{}.Eq(types.EntityUID(*s.Entity)), nil
 	case "in":
 		if s.Entity == nil {
 			return nil, fmt.Errorf("missing entity")
 		}
-		return ast.Scope{}.In(*s.Entity), nil
+		return ast.Scope{}.In(types.EntityUID(*s.Entity)), nil
 	case "is":
 		if s.In == nil {
 			return ast.Scope{}.Is(types.EntityType(s.EntityType)), nil
 		}
-		return ast.Scope{}.IsIn(types.EntityType(s.EntityType), s.In.Entity), nil
+		return ast.Scope{}.IsIn(types.EntityType(s.EntityType), types.EntityUID(s.In.Entity)), nil
 	}
 	return nil, fmt.Errorf("unknown op: %v", s.Op)
 }
@@ -48,12 +48,16 @@ func (s *scopeJSON) ToActionNode() (ast.IsActionScopeNode, error) {
 		if s.Entity == nil {
 			return nil, fmt.Errorf("missing entity")
 		}
-		return ast.Scope{}.Eq(*s.Entity), nil
+		return ast.Scope{}.Eq(types.EntityUID(*s.Entity)), nil
 	case "in":
 		if s.Entity != nil {
-			return ast.Scope{}.In(*s.Entity), nil
+			return ast.Scope{}.In(types.EntityUID(*s.Entity)), nil
 		}
-		return ast.Scope{}.InSet(s.Entities), nil
+		es := make([]types.EntityUID, len(s.Entities))
+		for i, e := range s.Entities {
+			es[i] = types.EntityUID(e)
+		}
+		return ast.Scope{}.InSet(es), nil
 	}
 	return nil, fmt.Errorf("unknown op: %v", s.Op)
 }

--- a/types/boolean.go
+++ b/types/boolean.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	"encoding/json"
-)
-
 // A Boolean is a value that is either true or false.
 type Boolean bool
 
@@ -27,9 +23,6 @@ func (v Boolean) MarshalCedar() []byte {
 	}
 	return []byte("false")
 }
-
-// ExplicitMarshalJSON marshals the Boolean into JSON.
-func (v Boolean) ExplicitMarshalJSON() ([]byte, error) { return json.Marshal(v) }
 
 func (v Boolean) hash() uint64 {
 	if v {

--- a/types/datetime.go
+++ b/types/datetime.go
@@ -286,16 +286,8 @@ func (a *Datetime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the encoding/json.Marshaler interface
-//
-// It produces the direct representation of a Cedar Datetime.
+// MarshalJSON Marshal's a Cedar Datetime with the explicit representation
 func (a Datetime) MarshalJSON() ([]byte, error) {
-	return []byte(`datetime("` + a.String() + `")`), nil
-}
-
-// ExplicitMarshalJSON Marshal's a Cedar Datetime with the explicit
-// representation
-func (a Datetime) ExplicitMarshalJSON() ([]byte, error) {
 	return json.Marshal(extValueJSON{
 		Extn: &extn{
 			Fn:  "datetime",

--- a/types/datetime_test.go
+++ b/types/datetime_test.go
@@ -198,6 +198,6 @@ func TestDatetime(t *testing.T) {
 		t.Parallel()
 		bs, err := types.FromStdTime(time.UnixMilli(42)).MarshalJSON()
 		testutil.OK(t, err)
-		testutil.Equals(t, string(bs), `datetime("1970-01-01T00:00:00.042Z")`)
+		testutil.Equals(t, string(bs), `{"__extn":{"fn":"datetime","arg":"1970-01-01T00:00:00.042Z"}}`)
 	})
 }

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -176,11 +176,8 @@ func (v *Decimal) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// ExplicitMarshalJSON marshals the Decimal into JSON using the implicit form.
-func (v Decimal) MarshalJSON() ([]byte, error) { return []byte(`"` + v.String() + `"`), nil }
-
-// ExplicitMarshalJSON marshals the Decimal into JSON using the explicit form.
-func (v Decimal) ExplicitMarshalJSON() ([]byte, error) {
+// MarshalJSON marshals the Decimal into JSON using the explicit form.
+func (v Decimal) MarshalJSON() ([]byte, error) {
 	return json.Marshal(extValueJSON{
 		Extn: &extn{
 			Fn:  "decimal",

--- a/types/duration.go
+++ b/types/duration.go
@@ -255,11 +255,8 @@ func (v *Duration) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON marshals the Duration into JSON using the implicit form.
-func (v Duration) MarshalJSON() ([]byte, error) { return []byte(`"` + v.String() + `"`), nil }
-
-// ExplicitMarshalJSON marshals the Decimal into JSON using the explicit form.
-func (v Duration) ExplicitMarshalJSON() ([]byte, error) {
+// MarshalJSON marshals the Duration into JSON using the explicit form.
+func (v Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(extValueJSON{
 		Extn: &extn{
 			Fn:  "duration",

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -177,7 +177,6 @@ func TestDuration(t *testing.T) {
 		t.Parallel()
 		bs, err := types.FromStdDuration(42 * time.Millisecond).MarshalJSON()
 		testutil.OK(t, err)
-		testutil.Equals(t, string(bs), `"42ms"`)
+		testutil.Equals(t, string(bs), `{"__extn":{"fn":"duration","arg":"42ms"}}`)
 	})
-
 }

--- a/types/entities.go
+++ b/types/entities.go
@@ -16,8 +16,28 @@ type Entities map[EntityUID]*Entity
 // An Entity defines the parents and attributes for an EntityUID.
 type Entity struct {
 	UID        EntityUID   `json:"uid"`
-	Parents    []EntityUID `json:"parents,omitempty"`
+	Parents    []EntityUID `json:"parents"`
 	Attributes Record      `json:"attrs"`
+}
+
+// MarshalJSON serializes Entity as a JSON object, using the implicit form of EntityUID encoding to match the Rust
+// SDK's behavior.
+func (e Entity) MarshalJSON() ([]byte, error) {
+	parents := make([]ImplicitlyMarshaledEntityUID, len(e.Parents))
+	for i, p := range e.Parents {
+		parents[i] = ImplicitlyMarshaledEntityUID(p)
+	}
+
+	m := struct {
+		UID        ImplicitlyMarshaledEntityUID   `json:"uid"`
+		Parents    []ImplicitlyMarshaledEntityUID `json:"parents"`
+		Attributes Record                         `json:"attrs"`
+	}{
+		ImplicitlyMarshaledEntityUID(e.UID),
+		parents,
+		e.Attributes,
+	}
+	return json.Marshal(m)
 }
 
 func (e Entities) MarshalJSON() ([]byte, error) {

--- a/types/entities_test.go
+++ b/types/entities_test.go
@@ -43,7 +43,7 @@ func TestEntitiesJSON(t *testing.T) {
 		e[ent2.UID] = ent2
 		b, err := e.MarshalJSON()
 		testutil.OK(t, err)
-		testutil.Equals(t, string(b), `[{"uid":{"type":"Type","id":"id"},"attrs":{"key":42}},{"uid":{"type":"Type","id":"id2"},"attrs":{"key":42}}]`)
+		testutil.Equals(t, string(b), `[{"uid":{"type":"Type","id":"id"},"parents":[],"attrs":{"key":42}},{"uid":{"type":"Type","id":"id2"},"parents":[],"attrs":{"key":42}}]`)
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {

--- a/types/entity_uid.go
+++ b/types/entity_uid.go
@@ -62,16 +62,8 @@ func (v *EntityUID) UnmarshalJSON(b []byte) error {
 	return errJSONEntityNotFound
 }
 
-// ExplicitMarshalJSON marshals the EntityUID into JSON using the implicit form.
+// MarshalJSON marshals the EntityUID into JSON using the explicit form.
 func (v EntityUID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(entityValueJSON{
-		Type: (*string)(&v.Type),
-		ID:   (*string)(&v.ID),
-	})
-}
-
-// ExplicitMarshalJSON marshals the EntityUID into JSON using the explicit form.
-func (v EntityUID) ExplicitMarshalJSON() ([]byte, error) {
 	return json.Marshal(entityValueJSON{
 		Entity: &extEntity{
 			Type: string(v.Type),
@@ -85,4 +77,17 @@ func (v EntityUID) hash() uint64 {
 	_, _ = h.Write([]byte(v.Type))
 	_, _ = h.Write([]byte(v.ID))
 	return h.Sum64()
+}
+
+// ImplicitlyMarshaledEntityUID exists to allow the marshaling of the EntityUID into JSON using the implicit form. Users
+// can opt in to this form if they know that this EntityUID will be serialized to a place where its type will be
+// unambiguous.
+type ImplicitlyMarshaledEntityUID EntityUID
+
+func (i ImplicitlyMarshaledEntityUID) MarshalJSON() ([]byte, error) {
+	s := struct {
+		Type EntityType `json:"type"`
+		ID   String     `json:"id"`
+	}{i.Type, i.ID}
+	return json.Marshal(s)
 }

--- a/types/ipaddr.go
+++ b/types/ipaddr.go
@@ -131,11 +131,8 @@ func (v *IPAddr) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// ExplicitMarshalJSON marshals the IPAddr into JSON using the implicit form.
-func (v IPAddr) MarshalJSON() ([]byte, error) { return []byte(`"` + v.String() + `"`), nil }
-
-// ExplicitMarshalJSON marshals the IPAddr into JSON using the explicit form.
-func (v IPAddr) ExplicitMarshalJSON() ([]byte, error) {
+// MarshalJSON marshals the IPAddr into JSON using the explicit form.
+func (v IPAddr) MarshalJSON() ([]byte, error) {
 	if v.Prefix().Bits() == v.Prefix().Addr().BitLen() {
 		return json.Marshal(extValueJSON{
 			Extn: &extn{

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/cedar-policy/cedar-go/internal/testutil"
@@ -85,7 +84,7 @@ func TestJSON_Value(t *testing.T) {
 
 			// Now assert that when we Marshal/Unmarshal that value, we still
 			// have what we started with
-			gotJSON, err := (*ptr).ExplicitMarshalJSON()
+			gotJSON, err := json.Marshal(ptr)
 			testutil.OK(t, err)
 			var gotRetry Value
 			ptr = &gotRetry
@@ -534,51 +533,61 @@ func TestTypedJSONUnmarshal(t *testing.T) {
 func TestJSONMarshal(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name        string
-		in          Value
-		outExplicit string
-		outImplicit string
+		name string
+		in   Value
+		out  string
 	}{
-		{"record", NewRecord(RecordMap{
-			"ak": String("av"),
-			"ck": String("cv"),
-			"bk": String("bv"),
-		}), `{"ak":"av","bk":"bv","ck":"cv"}`, `{"ak":"av","bk":"bv","ck":"cv"}`},
-		{"recordWithExt", NewRecord(RecordMap{
-			"ip": mustIPValue("222.222.222.7"),
-		}), `{"ip":{"__extn":{"fn":"ip","arg":"222.222.222.7"}}}`, `{"ip":{"__extn":{"fn":"ip","arg":"222.222.222.7"}}}`},
-		{"set", NewSet([]Value{
-			String("av"),
-			String("cv"),
-			String("bv"),
-		}), `["cv","bv","av"]`, `["cv","bv","av"]`},
-		{"setWithExt", NewSet([]Value{mustIPValue("222.222.222.7")}),
-			`[{"__extn":{"fn":"ip","arg":"222.222.222.7"}}]`, `[{"__extn":{"fn":"ip","arg":"222.222.222.7"}}]`},
-		{"entity", EntityUID{"User", "alice"}, `{"__entity":{"type":"User","id":"alice"}}`, `{"type":"User","id":"alice"}`},
-		{"ip", mustIPValue("222.222.222.7"), `{"__extn":{"fn":"ip","arg":"222.222.222.7"}}`, `"222.222.222.7"`},
-		{"decimal", mustDecimalValue("33.57"), `{"__extn":{"fn":"decimal","arg":"33.57"}}`, `"33.57"`},
+		{
+			"record",
+			NewRecord(RecordMap{
+				"ak": String("av"),
+				"ck": String("cv"),
+				"bk": String("bv"),
+			}),
+			`{"ak":"av","bk":"bv","ck":"cv"}`,
+		},
+		{
+			"recordWithExt",
+			NewRecord(RecordMap{
+				"ip": mustIPValue("222.222.222.7"),
+			}),
+			`{"ip":{"__extn":{"fn":"ip","arg":"222.222.222.7"}}}`,
+		},
+		{
+			"set",
+			NewSet([]Value{
+				String("av"),
+				String("cv"),
+				String("bv"),
+			}),
+			`["cv","bv","av"]`,
+		},
+		{
+			"entity",
+			EntityUID{"User", "alice"},
+			`{"__entity":{"type":"User","id":"alice"}}`,
+		},
+		{
+			"ip",
+			mustIPValue("222.222.222.7"),
+			`{"__extn":{"fn":"ip","arg":"222.222.222.7"}}`,
+		},
+		{
+			"decimal",
+			mustDecimalValue("33.57"),
+			`{"__extn":{"fn":"decimal","arg":"33.57"}}`,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			outExplicit, err := tt.in.ExplicitMarshalJSON()
+			out, err := json.Marshal(tt.in)
 			testutil.OK(t, err)
-			testutil.Equals(t, string(outExplicit), tt.outExplicit)
-			outImplicit, err := json.Marshal(tt.in)
-			testutil.OK(t, err)
-			testutil.Equals(t, string(outImplicit), tt.outImplicit)
+			testutil.Equals(t, string(out), tt.out)
 		})
 	}
 }
-
-type jsonErr struct{}
-
-func (j *jsonErr) String() string                       { return "" }
-func (j *jsonErr) MarshalCedar() []byte                 { return nil }
-func (j *jsonErr) Equal(Value) bool                     { return false }
-func (j *jsonErr) ExplicitMarshalJSON() ([]byte, error) { return nil, fmt.Errorf("jsonErr") }
-func (j *jsonErr) hash() uint64                         { return 0 }
 
 func TestJSONSet(t *testing.T) {
 	t.Parallel()
@@ -586,12 +595,6 @@ func TestJSONSet(t *testing.T) {
 		t.Parallel()
 		var s Set
 		err := json.Unmarshal([]byte(`[{"__extn":{"fn":"err"}}]`), &s)
-		testutil.Error(t, err)
-	})
-	t.Run("MarshalErr", func(t *testing.T) {
-		t.Parallel()
-		s := NewSet([]Value{&jsonErr{}})
-		_, err := json.Marshal(s)
 		testutil.Error(t, err)
 	})
 }
@@ -613,11 +616,5 @@ func TestJSONRecord(t *testing.T) {
 		// this demonstrates that invalid keys will still result in json
 		testutil.Equals(t, string(v), `{"\ufffd\u0001":false}`)
 		testutil.OK(t, err)
-	})
-	t.Run("MarshalValueErr", func(t *testing.T) {
-		t.Parallel()
-		r := NewRecord(RecordMap{"key": &jsonErr{}})
-		_, err := json.Marshal(r)
-		testutil.Error(t, err)
 	})
 }

--- a/types/long.go
+++ b/types/long.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -28,9 +27,6 @@ func (a Long) LessThanOrEqual(bi Value) (bool, error) {
 	}
 	return a <= b, nil
 }
-
-// ExplicitMarshalJSON marshals the Long into JSON.
-func (v Long) ExplicitMarshalJSON() ([]byte, error) { return json.Marshal(v) }
 
 // String produces a string representation of the Long, e.g. `42`.
 func (v Long) String() string { return fmt.Sprint(int64(v)) }

--- a/types/record.go
+++ b/types/record.go
@@ -120,7 +120,7 @@ func (v Record) MarshalJSON() ([]byte, error) {
 		w.Write(kb)
 		w.WriteByte(':')
 		vv := v.m[kk]
-		vb, err := vv.ExplicitMarshalJSON()
+		vb, err := json.Marshal(vv)
 		if err != nil {
 			return nil, err
 		}
@@ -129,10 +129,6 @@ func (v Record) MarshalJSON() ([]byte, error) {
 	w.WriteByte('}')
 	return w.Bytes(), nil
 }
-
-// ExplicitMarshalJSON marshals the Record into JSON, the marshaller uses the
-// explicit JSON form for all the values in the Record.
-func (v Record) ExplicitMarshalJSON() ([]byte, error) { return v.MarshalJSON() }
 
 // String produces a string representation of the Record, e.g. `{"a":1,"b":2,"c":3}`.
 func (r Record) String() string { return string(r.MarshalCedar()) }

--- a/types/set.go
+++ b/types/set.go
@@ -129,9 +129,8 @@ func (v *Set) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON marshals the Set into JSON, the marshaller uses the explicit JSON
-// form for all the values in the Set and always orders elements by their hash
-// hash order, which may differ from the original order.
+// MarshalJSON marshals the Set into JSON.
+// Set elements are rendered in hash order, which may differ from the original order.
 func (v Set) MarshalJSON() ([]byte, error) {
 	w := &bytes.Buffer{}
 	w.WriteByte('[')
@@ -141,7 +140,7 @@ func (v Set) MarshalJSON() ([]byte, error) {
 		if i != 0 {
 			w.WriteByte(',')
 		}
-		b, err := v.s[k].ExplicitMarshalJSON()
+		b, err := json.Marshal(v.s[k])
 		if err != nil {
 			return nil, err
 		}
@@ -150,10 +149,6 @@ func (v Set) MarshalJSON() ([]byte, error) {
 	w.WriteByte(']')
 	return w.Bytes(), nil
 }
-
-// ExplicitMarshalJSON marshals the Set into JSON, the marshaller uses the
-// explicit JSON form for all the values in the Set.
-func (v Set) ExplicitMarshalJSON() ([]byte, error) { return v.MarshalJSON() }
 
 // String produces a string representation of the Set, e.g. `[1,2,3]`.
 func (v Set) String() string { return string(v.MarshalCedar()) }

--- a/types/set_internal_test.go
+++ b/types/set_internal_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"slices"
 	"testing"
 
@@ -13,11 +12,10 @@ type colliderValue struct {
 	HashVal uint64
 }
 
-func (c colliderValue) String() string                       { return "" }
-func (c colliderValue) MarshalCedar() []byte                 { return nil }
-func (c colliderValue) Equal(v Value) bool                   { return v.Equal(c.Value) }
-func (c colliderValue) ExplicitMarshalJSON() ([]byte, error) { return nil, fmt.Errorf("colliderValue") }
-func (c colliderValue) hash() uint64                         { return c.HashVal }
+func (c colliderValue) String() string       { return "" }
+func (c colliderValue) MarshalCedar() []byte { return nil }
+func (c colliderValue) Equal(v Value) bool   { return v.Equal(c.Value) }
+func (c colliderValue) hash() uint64         { return c.HashVal }
 
 func TestSet(t *testing.T) {
 	t.Parallel()

--- a/types/string.go
+++ b/types/string.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"hash/fnv"
 	"strconv"
 )
@@ -13,9 +12,6 @@ func (a String) Equal(bi Value) bool {
 	b, ok := bi.(String)
 	return ok && a == b
 }
-
-// ExplicitMarshalJSON marshals the String into JSON.
-func (v String) ExplicitMarshalJSON() ([]byte, error) { return json.Marshal(v) }
 
 // String produces an unquoted string representation of the String, e.g. `hello`.
 func (v String) String() string {

--- a/types/value.go
+++ b/types/value.go
@@ -18,10 +18,6 @@ type Value interface {
 	fmt.Stringer
 	// MarshalCedar produces a valid MarshalCedar language representation of the Value.
 	MarshalCedar() []byte
-	// ExplicitMarshalJSON marshals the Value into JSON using the explicit (if
-	// applicable) JSON form, which is necessary for marshalling values within
-	// Sets or Records where the type is not defined.
-	ExplicitMarshalJSON() ([]byte, error)
 	Equal(Value) bool
 	hash() uint64
 }


### PR DESCRIPTION
Entities and extension functions have both an "implict" and "explict" form of JSON serialization, where the "implicit" form is only valid if the serialized data can be unambiguously determined to be of a given type. This can happen positionally (e.g. EntityUIDs in the serialization of the Entities object) or via knowledge gleaned from a schema (which we don't yet support).

It's _always_ safe to encode an entity or extension function via the "explicit" form, so let's make that the default. This also alleviates the types that don't have implicit and explicit forms from having to implement ExplicitMarshalJSON.

With this approach, callers who know that it's safe to use the implicit form can do so and everyone else will get the safe explicit form. The two existing callers that use the implicit form are the JSON serialization of Entities and the scope operators which always take EntityUIDs.