### PR TITLE
CI: realworld corpus workflow + corpus schema export

### DIFF
--- a/.github/workflows/export-corpus-json-schemas.yml
+++ b/.github/workflows/export-corpus-json-schemas.yml
@@ -1,0 +1,26 @@
+name: Export Corpus JSON Schemas
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 2 * * 0"
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Export JSON schemas
+        run: go run ./cmd/corpus-json-schemas --in corpus-tests.tar.gz --out corpus-tests-json-schemas.tar.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: corpus-tests-json-schemas
+          path: corpus-tests-json-schemas.tar.gz

--- a/.github/workflows/realworld.yml
+++ b/.github/workflows/realworld.yml
@@ -1,0 +1,20 @@
+name: Realworld (Corpus) Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  corpus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run corpus tests
+        run: go test -run '^TestCorpus$' ./...

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tmp/
 .DS_Store
 coverage.out
+corpus-tests-json-schemas.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: corpus-tests-json-schemas
+corpus-tests-json-schemas: corpus-tests-json-schemas.tar.gz
+
+corpus-tests-json-schemas.tar.gz: corpus-tests.tar.gz
+	@echo "Generating JSON schemas from Cedar schemas (corpus tests)..."
+	@go run ./cmd/corpus-json-schemas --in corpus-tests.tar.gz --out corpus-tests-json-schemas.tar.gz
+	@echo "Done! Created corpus-tests-json-schemas.tar.gz"

--- a/cmd/corpus-json-schemas/main.go
+++ b/cmd/corpus-json-schemas/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/cedar-policy/cedar-go/x/exp/schema"
+)
+
+func main() {
+	inPath := flag.String("in", "corpus-tests.tar.gz", "input corpus tar.gz")
+	outPath := flag.String("out", "corpus-tests-json-schemas.tar.gz", "output tar.gz of JSON schemas")
+	allowErrors := flag.Bool("allow-errors", true, "continue on schema translation errors")
+	flag.Parse()
+
+	if err := run(*inPath, *outPath, *allowErrors); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(inPath, outPath string, allowErrors bool) error {
+	inFile, err := os.Open(inPath)
+	if err != nil {
+		return fmt.Errorf("open input: %w", err)
+	}
+	defer func() { _ = inFile.Close() }()
+
+	gzr, err := gzip.NewReader(inFile)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer func() { _ = gzr.Close() }()
+
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("create output: %w", err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	gzw := gzip.NewWriter(outFile)
+	defer func() { _ = gzw.Close() }()
+
+	tw := tar.NewWriter(gzw)
+	defer func() { _ = tw.Close() }()
+
+	tr := tar.NewReader(gzr)
+
+	var failures int
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if !strings.HasSuffix(hdr.Name, ".cedarschema") {
+			continue
+		}
+
+		cedarBytes, err := io.ReadAll(tr)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", hdr.Name, err)
+		}
+
+		var s schema.Schema
+		s.SetFilename(hdr.Name)
+		err = s.UnmarshalCedar(cedarBytes)
+		var outBytes []byte
+		if err == nil {
+			outBytes, err = s.MarshalJSON()
+		}
+		if err != nil {
+			failures++
+			if !allowErrors {
+				return fmt.Errorf("translate %s: %w", hdr.Name, err)
+			}
+			outBytes = []byte(fmt.Sprintf("error translating %s: %v\n", hdr.Name, err))
+		}
+
+		base := strings.TrimSuffix(path.Base(hdr.Name), ".cedarschema")
+		outName := path.Join("corpus-tests-json-schemas", base+".cedarschema.json")
+		outHdr := &tar.Header{
+			Name: outName,
+			Mode: 0o644,
+			Size: int64(len(outBytes)),
+		}
+		if err := tw.WriteHeader(outHdr); err != nil {
+			return fmt.Errorf("write header for %s: %w", outName, err)
+		}
+		if _, err := tw.Write(outBytes); err != nil {
+			return fmt.Errorf("write %s: %w", outName, err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("finalize tar: %w", err)
+	}
+	if err := gzw.Close(); err != nil {
+		return fmt.Errorf("finalize gzip: %w", err)
+	}
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("close output: %w", err)
+	}
+
+	if failures > 0 {
+		fmt.Fprintf(os.Stderr, "warning: failed to translate %d schema(s) (see output files for details)\n", failures)
+	}
+	return nil
+}


### PR DESCRIPTION
$This PR extracts the *workflow + data-export* intent from PR #14 (Schema v2) while deliberately excluding all schema2 implementation changes.

What it adds:
- `realworld.yml`: scheduled/manual workflow that runs the corpus ("realworld") integration tests.
- `export-corpus-json-schemas.yml`: scheduled/manual workflow that exports `.cedarschema` files from `corpus-tests.tar.gz` to JSON and uploads the result as an artifact.
- `cmd/corpus-json-schemas`: small Go exporter used by CI and `make corpus-tests-json-schemas`.

Notes:
- The exporter uses the existing `x/exp/schema` package, so it works on `main` without schema2.
- Export continues on individual schema failures by default (mirrors the permissive behavior in PR #14’s Makefile).